### PR TITLE
敵カードの処理をイベント方式に変更し、BattleManager に移してリファクタリング。バトル周りのバグ修正。

### DIFF
--- a/Assets/Prefabs/BackPackItem.prefab
+++ b/Assets/Prefabs/BackPackItem.prefab
@@ -749,10 +749,10 @@ RectTransform:
   - {fileID: 4873598420760563052}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &741309513820039015
 CanvasRenderer:
@@ -1197,7 +1197,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 26.1, y: 38.2}
+  m_AnchoredPosition: {x: 35.6, y: 38.2}
   m_SizeDelta: {x: 30, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1190081958179348600
@@ -1273,7 +1273,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -65.29999}
+  m_AnchoredPosition: {x: 0, y: -63}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5400610706632780805

--- a/Assets/Scenes/Stage.unity
+++ b/Assets/Scenes/Stage.unity
@@ -458,7 +458,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 754, y: -68}
+  m_AnchoredPosition: {x: 715, y: -68}
   m_SizeDelta: {x: 235, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &37657222
@@ -2972,7 +2972,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -161.3, y: 16}
+  m_AnchoredPosition: {x: -226.3, y: 16}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &249478006
@@ -3253,6 +3253,7 @@ MonoBehaviour:
   inputLocked: 0
   flipDuration: 0.3
   btnStairs: {fileID: 1618478252}
+  btnRetry: {fileID: 351684363}
   cgSlotSet: {fileID: 1416203356}
   txtFlipPoint: {fileID: 927539151}
   txtFloorCount: {fileID: 255625484}
@@ -3873,6 +3874,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5160fe6bfabdeac4a931fb07377bf2df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isDontDestroy: 0
   itemInfoCanvas: {fileID: 1923410984}
   imgItemIcon: {fileID: 412275113}
   imgRarityIcons:
@@ -4246,6 +4248,126 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 343536243}
+  m_CullTransparentMesh: 1
+--- !u!1 &351684361
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 351684362}
+  - component: {fileID: 351684365}
+  - component: {fileID: 351684364}
+  - component: {fileID: 351684363}
+  m_Layer: 5
+  m_Name: btnRetry
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &351684362
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 351684361}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6985294761353623262}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 885, y: -183}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &351684363
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 351684361}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 351684364}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &351684364
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 351684361}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: faf8f0eeb5cd1204699cb452ee5fcba1, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &351684365
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 351684361}
   m_CullTransparentMesh: 1
 --- !u!1 &361983756
 GameObject:
@@ -7379,8 +7501,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 276495858}
   m_HandleRect: {fileID: 276495857}
   m_Direction: 0
-  m_Value: 0
-  m_Size: 0.5000821
+  m_Value: 1
+  m_Size: 0.98595965
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -10619,11 +10741,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7791461220476687418, guid: 660db9131cd6107428728ba1fb32861d, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.759
+      value: 0.684
       objectReference: {fileID: 0}
     - target: {fileID: 7791461220476687418, guid: 660db9131cd6107428728ba1fb32861d, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.345
       objectReference: {fileID: 0}
     - target: {fileID: 7791461220476687418, guid: 660db9131cd6107428728ba1fb32861d, type: 3}
       propertyPath: m_LocalPosition.z
@@ -11298,7 +11420,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1093616886
 RectTransform:
   m_ObjectHideFlags: 0
@@ -11316,7 +11438,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -310}
+  m_AnchoredPosition: {x: 393, y: 9}
   m_SizeDelta: {x: 180, y: 180}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1093616887
@@ -12037,6 +12159,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a0fb3531f0021b14c8c33f13ea365827, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::BattleManager
+  isDontDestroy: 0
   playerFloatingViewTran: {fileID: 1316073536}
   enemyFloatingViewTran: {fileID: 185188495}
   PlayerHP:
@@ -12111,7 +12234,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -56.5, y: 0.8}
+  m_AnchoredPosition: {x: -67.6, y: 0.8}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1194597803
@@ -15122,6 +15245,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 84fe14f969832144486a4a182c37880f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isDontDestroy: 0
   enemyInfoCanvas: {fileID: 2129386119}
   imgEnemyIcon: {fileID: 1017239769}
   imgShadeIcon: {fileID: 1316491465}
@@ -15970,6 +16094,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5da7f667a7ea7644799a3c028e34e6fb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PlayerInventoryManager
+  isDontDestroy: 0
   backPackItemGenerator: {fileID: 1599291612}
   txtCurrentInventorySize: {fileID: 1719853293}
   txtMaxInventorySize: {fileID: 2114746172}
@@ -16130,7 +16255,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 598.2, y: -183}
+  m_AnchoredPosition: {x: 548, y: -183}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1618478252
@@ -17047,8 +17172,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.15, y: 0.000019073}
-  m_SizeDelta: {x: 110.23, y: 100}
+  m_AnchoredPosition: {x: -18, y: 3.1}
+  m_SizeDelta: {x: 210.74, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1719853292
 MonoBehaviour:
@@ -17088,11 +17213,11 @@ MonoBehaviour:
       m_Calls: []
   m_FontData:
     m_Font: {fileID: 12800000, guid: e5ce7090eff7556438a6272f66c46d74, type: 3}
-    m_FontSize: 70
+    m_FontSize: 100
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 1
-    m_MaxSize: 120
+    m_MinSize: 0
+    m_MaxSize: 195
     m_Alignment: 5
     m_AlignByGeometry: 0
     m_RichText: 1
@@ -17397,8 +17522,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 2400, y: 1500}
+  m_AnchoredPosition: {x: 349.35315, y: 0}
+  m_SizeDelta: {x: 1701.294, y: 1500}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1740415744
 MonoBehaviour:
@@ -17457,7 +17582,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.7607843}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -17697,6 +17822,7 @@ MonoBehaviour:
   txtWaveInfo: {fileID: 0}
   txtInventoryMaxInfo: {fileID: 1953483849}
   txtRestartMessage: {fileID: 107718666}
+  txtSettlementInfo: {fileID: 1972840752}
   sliderHp: {fileID: 6766392416987139762}
   btnPlayerLevel: {fileID: 0}
   canvasTran: {fileID: 0}
@@ -17709,6 +17835,8 @@ MonoBehaviour:
   - {fileID: 21300000, guid: a4fb099bf4061d64281d039ca6531549, type: 3}
   - {fileID: 21300000, guid: c374ac9f58d27a74e88a697e91b2bee1, type: 3}
   inventoryFilter: {fileID: 1676759297}
+  releaseMessageColor: {r: 0, g: 0, b: 1, a: 0.69411767}
+  circleOutline: {fileID: 1972840753}
   playerBackPackItemTran: {fileID: 4003654539442634172}
   enemyBackPackItemTran: {fileID: 0}
 --- !u!4 &1768058887
@@ -18029,8 +18157,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 8}
-  m_SizeDelta: {x: 365.7, y: 595}
+  m_AnchoredPosition: {x: 0, y: -6.832489}
+  m_SizeDelta: {x: 365.7, y: 624.66}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1793019903
 MonoBehaviour:
@@ -20074,12 +20202,12 @@ GameObject:
   - component: {fileID: 1972840752}
   - component: {fileID: 1972840753}
   m_Layer: 5
-  m_Name: txtNotReleasePowerSpotInfo
+  m_Name: txtSettlementInfo
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &1972840752
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -20093,7 +20221,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -20372,8 +20500,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -722, y: 349}
-  m_SizeDelta: {x: 188.14, y: 46.26}
+  m_AnchoredPosition: {x: -722, y: 324}
+  m_SizeDelta: {x: 200, y: 55}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1989763077
 MonoBehaviour:
@@ -20852,8 +20980,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -103.39, y: -1.0249991}
-  m_SizeDelta: {x: 185.33, y: 59.95}
+  m_AnchoredPosition: {x: -139.44, y: -1.0249991}
+  m_SizeDelta: {x: 257.43, y: 59.95}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2033560242
 MonoBehaviour:
@@ -22029,8 +22157,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 80.246, y: 0.000019073}
-  m_SizeDelta: {x: 182.73, y: 100}
+  m_AnchoredPosition: {x: 74.9, y: -1.4}
+  m_SizeDelta: {x: 182.73, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2114746171
 MonoBehaviour:
@@ -22073,7 +22201,7 @@ MonoBehaviour:
     m_FontSize: 70
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 1
+    m_MinSize: 0
     m_MaxSize: 120
     m_Alignment: 3
     m_AlignByGeometry: 0
@@ -22252,7 +22380,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 90}
+  m_AnchoredPosition: {x: 0, y: -157}
   m_SizeDelta: {x: 580, y: 600}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &2129386119
@@ -22731,15 +22859,15 @@ MonoBehaviour:
   m_Padding:
     m_Left: 35
     m_Right: 0
-    m_Top: 40
-    m_Bottom: 80
+    m_Top: 115
+    m_Bottom: 110
   m_ChildAlignment: 0
   m_StartCorner: 0
   m_StartAxis: 0
-  m_CellSize: {x: 80, y: 80}
-  m_Spacing: {x: 25, y: 40}
+  m_CellSize: {x: 50, y: 50}
+  m_Spacing: {x: 55.1, y: 115}
   m_Constraint: 1
-  m_ConstraintCount: 3
+  m_ConstraintCount: 4
 --- !u!224 &1777668276301124855
 RectTransform:
   m_ObjectHideFlags: 0
@@ -23299,7 +23427,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -22}
+  m_AnchoredPosition: {x: -39, y: -22}
   m_SizeDelta: {x: 300, y: 300}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &3332258711609959592
@@ -23458,15 +23586,15 @@ RectTransform:
   m_GameObject: {fileID: 3154047844736015411}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 0.8, y: 0.8, z: 0.8}
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 1793019902}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.0149383545, y: 13.665009}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -0.014968872, y: 13.667511}
+  m_SizeDelta: {x: -130.7, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &4023111113357351616
 MonoBehaviour:
@@ -23891,6 +24019,7 @@ RectTransform:
   - {fileID: 5116131266064846519}
   - {fileID: 1416203354}
   - {fileID: 1618478251}
+  - {fileID: 351684362}
   - {fileID: 3651254416758909861}
   - {fileID: 1107409557}
   - {fileID: 2063089795}

--- a/Assets/Scenes/Title.unity
+++ b/Assets/Scenes/Title.unity
@@ -2231,6 +2231,10 @@ PrefabInstance:
       value: 19
       objectReference: {fileID: 0}
     - target: {fileID: 2323247000860799173, guid: c356020638cee7b46acab21e1c4454e0, type: 3}
+      propertyPath: isDontDestroy
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2323247000860799173, guid: c356020638cee7b46acab21e1c4454e0, type: 3}
       propertyPath: 'SE.Array.data[16]'
       value: 
       objectReference: {fileID: 8300000, guid: e891c3f9a7b0eb847b045ca72dd1704c, type: 3}
@@ -5285,6 +5289,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7125656954279440095, guid: 9399b890523a5c24ca68b4e7de53fdc0, type: 3}
+      propertyPath: isDontDestroy
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -7691,6 +7699,10 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 237094297761315668, guid: b444b0974ae37b04bbc6fbbfb1744e12, type: 3}
       propertyPath: fadeDuration
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 237094297761315668, guid: b444b0974ae37b04bbc6fbbfb1744e12, type: 3}
+      propertyPath: isDontDestroy
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1634721240851707581, guid: b444b0974ae37b04bbc6fbbfb1744e12, type: 3}

--- a/Assets/Scripts/Chara/Common/UI/FloatingView.cs
+++ b/Assets/Scripts/Chara/Common/UI/FloatingView.cs
@@ -15,7 +15,7 @@ public enum FloatingViewType {
 /// <summary>
 /// フロート表示用
 /// </summary>
-public class FloatingView : TextViewBase, IPoolable {
+public class FloatingView : TextViewBase {
 
     [SerializeField] private bool isAnimOn;
 
@@ -131,10 +131,15 @@ public class FloatingView : TextViewBase, IPoolable {
     /// オブジェクトプールへ戻す
     /// </summary>
     public override void Release() {
+        if (isReleased) {
+            return;
+        }
+
         // 文字の色を白に戻す
         SetDefaultColorAndFontSize();
 
         // フェードアウトした後に初期値に戻す
+        if (this == null || canvasGroupTextView == null) return;
         canvasGroupTextView.alpha = 1.0f;
         transform.localScale = Vector3.one * defaultScale;
         floatingViewType = FloatingViewType.normalDamage;

--- a/Assets/Scripts/Manager/MemoryGameManager.cs
+++ b/Assets/Scripts/Manager/MemoryGameManager.cs
@@ -24,6 +24,7 @@ public class MemoryGameManager : MonoBehaviour {
     [SerializeField] private float flipDuration = 0.3f;
 
     [SerializeField] private Button btnStairs;
+    [SerializeField] private Button btnRetry;
     [SerializeField] private CanvasGroup cgSlotSet;
     [SerializeField] private Text txtFlipPoint;
     [SerializeField] private Text txtFloorCount;
@@ -85,8 +86,18 @@ public class MemoryGameManager : MonoBehaviour {
             .AddTo(this);
 
         // 階段ボタンの購読
+        if (this == null || btnStairs == null) return;
         btnStairs
             .OnClickExt(() => NextFloorAsync().Forget(), this);
+
+        // リトライボタンの購読
+        if (this == null || btnRetry == null) return;
+        btnRetry
+            .OnClickExt(() => {
+                if (GameData.instance.CurrentGameState.Value != GameData.GameState.Play) {
+                    return;
+                }
+                GameEndAsync().Forget(); }, this);
 
         // めくれる回数の残り回数を確認し、ゲーム終了処理へつなげる
         GameData.instance.userData.FlipPoint
@@ -139,6 +150,7 @@ public class MemoryGameManager : MonoBehaviour {
         // カードの情報準備と生成
         await SetupCardsAsync();
 
+        if (this == null || cgSlotSet == null) return;
         cgSlotSet.blocksRaycasts = true;
     }
 
@@ -172,6 +184,8 @@ public class MemoryGameManager : MonoBehaviour {
         for (int i = 0; i < selectedCardDataList.Count; i++) {
             int index = i;
             await UniTask.Delay(200);
+
+            if (this == null || cardGenerator == null || slotList == null) return;
             CardView card = (CardView)cardGenerator.GetObjectFromPool(slotList[i].transform);
             card.Setup(index, OnCardSelected, flipDuration, selectedCardDataList[i].cardTypeMaster.spriteCardType);
             cardViewList.Add(card);
@@ -399,6 +413,7 @@ public class MemoryGameManager : MonoBehaviour {
                 selectedCardModel.cardData.masterData = CreateCardData(selectedCardModel.cardData.cardTypeMaster.cardEventType, currentFloorData);
 
                 // カードの効果を実行
+                if (this == null || selectedCardModel == null || cts == null) return;
                 await selectedCardModel.ExecuteCardAsync(cts.Token);
 
                 // すべてのカードを引き終わっているか確認
@@ -537,12 +552,22 @@ public class MemoryGameManager : MonoBehaviour {
 
     private async UniTask GameEndAsync() {
         cgSlotSet.blocksRaycasts = false;
+        btnRetry.interactable = false;
+        btnStairs.interactable = false;
+
+        if (cts != null) {
+            cts.Cancel();  // すべての Hoge メソッドの実行をキャンセルする
+            cts.Dispose(); // 古いトークンソースを破棄
+            cts = null;    // 参照をクリア
+            DebugLogger.Log("Cancel");
+        }
 
         await UniTask.Delay(500);
         DebugLogger.Log($"ゲーム終了");
 
 #if UNITY_EDITOR
-        UnityEditor.EditorApplication.isPlaying = false;  // エディター再生を停止
+        SceneStateManager.instance.PrepareteNextScene(SceneName.Stage);
+        //UnityEditor.EditorApplication.isPlaying = false;  // エディター再生を停止
 #else
     Application.Quit();  // ビルド後はアプリ終了
 #endif

--- a/Assets/Scripts/MemoryGame/CardView.cs
+++ b/Assets/Scripts/MemoryGame/CardView.cs
@@ -50,6 +50,8 @@ public class CardView : PoolBase {
     public override void Release() {
         base.Release();
 
+        if (this == null || transform == null) return;
+
         transform.SetParent(GameData.instance.transform);
         rectTransform.localScale = Vector3.one;
         rectTransform.localPosition = Vector3.zero;

--- a/Assets/Scripts/MemoryGame/EnemyCard.cs
+++ b/Assets/Scripts/MemoryGame/EnemyCard.cs
@@ -9,45 +9,8 @@ public class EnemyCard : CardModelBase {
         DebugLogger.Log("Enemy");
 
         if (cardData.masterData is EnemyData enemyData) {
-            BattleResultType battleResultType = await BattleManager.instance.StartBattle(enemyData, TurnState.Player);
-
-            // TODO OnNext で StageLogicManager の購読をキックする
-
-
-            if (battleResultType == BattleResultType.Win) {
-                // 討伐した敵を登録
-                GameData.instance.AddDefeatEnemyList(enemyData.enemyNo);
-                
-                // 経験値獲得
-                GameData.instance.userData.SoulPoint.Value += enemyData.exp;
-
-                // 敵のレアリティから同レアリティのアイテムテータを抽選
-                ItemData itemData = DataBaseManager.instance.GetRandomItemByEnemyDrop(enemyData.rarity);
-
-                // カードの種類とマスターデータを設定
-                CardData cardData = new() {
-                    cardTypeMaster = DataBaseManager.instance.GetCardType(CardEventType.TreasureChest),
-                    masterData = itemData
-                };
-
-                // 宝箱カードの生成、カードの効果を実行
-                TreasureChestCard treasureChestCard = new(cardData, true);
-                await treasureChestCard.ExecuteCardAsync(token);
-
-                GameData.instance.CurrentGameState.Value = GameData.GameState.Play;
-            } else if (battleResultType == BattleResultType.Lose) {
-                DebugLogger.Log($"Game Over");
-                GameData.instance.CurrentGameState.Value = GameData.GameState.GameUp;
-
-                SoundManager.instance.PlayVoice(VOICE_TYPE.Loose);
-                //stageUIManager.ShowRestartMessage();
-
-                await UniTask.WaitUntil(() => UnityEngine.Input.GetMouseButtonDown(0), cancellationToken: token);
-                SceneStateManager.instance.PrepareteNextScene(SceneName.Title);
-            } else if (battleResultType == BattleResultType.Timeout) {
-                DebugLogger.Log($"Timeout");
-                GameData.instance.CurrentGameState.Value = GameData.GameState.Play;
-            }
+            // 交渉の成功可否判定などをしてから、バトル開始
+            await BattleManager.instance.StartBattleAsync(enemyData, TurnState.Player);
         }
 
         await UniTask.Yield(token);

--- a/Assets/Scripts/MemoryGame/MemoryFragmentsCard.cs
+++ b/Assets/Scripts/MemoryGame/MemoryFragmentsCard.cs
@@ -3,7 +3,7 @@ using System.Threading;
 
 [System.Serializable]
 public class MemoryFragmentsCard : CardModelBase {
-    public MemoryFragmentsCard(CardData cardData) : base(cardData) {}
+    public MemoryFragmentsCard(CardData cardData) : base(cardData) { }
 
     public override async UniTask ExecuteCardAsync(CancellationToken token) {
         DebugLogger.Log("MemoryFragments");
@@ -11,10 +11,14 @@ public class MemoryFragmentsCard : CardModelBase {
         SoundManager.instance.PlaySE(SE_TYPE.PowerSpot);
 
         // TODO CardData を指定のマスターに変換して値を取得
+        if (cardData.masterData is MemoryStoneData memoryStoneData) {
+            // 思い出の秘石の獲得数を加算、秘石をスロットにセット
+            GameData.instance.AddMemoryStoneList(memoryStoneData.id, memoryStoneData.addFlipCount);
+        } else {
+            // 見つからない場合には固定値で加算
+            GameData.instance.AddMemoryStoneList(1, 3);
+        }
 
-        // 思い出の秘石の獲得数を加算、秘石をスロットにセット
-        GameData.instance.AddMemoryStoneList(1, 3);
-        
         await UniTask.Yield(token);
     }
 }

--- a/Assets/Scripts/MemoryGame/TreasureChestCard.cs
+++ b/Assets/Scripts/MemoryGame/TreasureChestCard.cs
@@ -24,7 +24,7 @@ public class TreasureChestCard : CardModelBase {
                 SoundManager.instance.PlaySE(SE_TYPE.OpenTreasure);
             }
 
-            await UniTask.Delay(300, cancellationToken: token);
+            await UniTask.Delay(300, cancellationToken: token).SuppressCancellationThrow();
 
             // 入手したアイテムの情報表示
             await ItemInfoDisplayManager.instance.ShowTreasureItemInfoAsync(itemData, token);

--- a/Assets/Scripts/Utility/Common/AbstractSingleton.cs
+++ b/Assets/Scripts/Utility/Common/AbstractSingleton.cs
@@ -7,11 +7,14 @@
 public abstract class AbstractSingleton<T> : MonoBehaviour where T : Component {
 
     public static T instance;
+    public bool isDontDestroy;
 
     protected virtual void Awake() {
         if (instance == null) {
             instance = this as T;
-            DontDestroyOnLoad(gameObject);
+            if (isDontDestroy) {
+                DontDestroyOnLoad(gameObject);
+            }
         } else {
             Destroy(gameObject);
         }

--- a/Assets/Scripts/Wodertale/BackPackInItem.cs
+++ b/Assets/Scripts/Wodertale/BackPackInItem.cs
@@ -77,6 +77,7 @@ public class BackPackInItem : PoolBase {
 
         //Debug.Log("SetupBackPackItem");
         float scale = transform.localScale.x;
+        UpdateEnhanceLevelDisplay(0);
 
         transform.localPosition = new(transform.localPosition.x, transform.localPosition.y, 0);
         transform.localScale = Vector3.zero;
@@ -92,6 +93,7 @@ public class BackPackInItem : PoolBase {
                 ExecuteBackPackItem(this.itemData, cts.Token, entityType, resultType).Forget();
             });
 
+        EnhanceLevel.Value = 0;
         enhanceLevelDispose = EnhanceLevel.Subscribe(level => UpdateEnhanceLevelDisplay(level));
 
         battleEndDisposable = BattleManager.instance.OnBattleEnd
@@ -100,31 +102,34 @@ public class BackPackInItem : PoolBase {
 
                 // プレイヤーの際、バトルで1回も消費していない場合、あるいはパッシブの場合には耐久値を1回分だけ減らす
                 // 必ず this で、新しく作成した ItemData を参照する
-                //if (entityType == EntityType.Player &&
-                //    (prevDurability == this.itemData.durability || this.itemData.effectType == EffectType.Passive)) {
-                //    this.itemData.durability--;
-                //    if (this.itemData.durability <= 0) {
-                //        UpdateDurabilityDisplay(0);
-                //        AddPriceToMoney(ReleaseType.Destroy);  // 0 だが一応
-                //        Release();
-                //    } else {
-                //        UpdateDurabilityDisplay(this.itemData.durability);
-                //    }
-                //    DebugLogger.Log(this.itemData.durability);
-                //}
+                if (entityType == EntityType.Player &&
+                    (prevDurability == this.itemData.durability || this.itemData.effectType == EffectType.Passive)) {
+                    this.itemData.durability--;
+                    if (this.itemData.durability <= 0) {
+                        UpdateDurabilityDisplay(0);
+                        AddPriceToMoney(ReleaseType.Destroy);  // 0 だが一応
+                        Release();
+                    } else {
+                        UpdateDurabilityDisplay(this.itemData.durability);
+                    }
+                    DebugLogger.Log(this.itemData.durability);
+                }
 
                 // 穢れのコンディションの場合に、1回ずつ減らす
 
 
                 tweener?.Kill();
                 int attackInterval = Mathf.CeilToInt(currentCoolTime * 1000); // 1000 でスケールして切り上げ
-                await UniTask.Delay(attackInterval);
+                await UniTask.Delay(attackInterval, cancellationToken: token).SuppressCancellationThrow();
+
+                if (this == null || imgIconGauge == null) return;
                 tweener = imgIconGauge.DOFillAmount(1.0f, 0.2f).SetEase(Ease.Linear).SetLink(gameObject);
             });
 
         // 耐久値表示更新
         if (entityType == EntityType.Player) {
-            UpdateDurabilityDisplay(-1);
+            UpdateDurabilityDisplay(this.itemData.durability);
+            //UpdateDurabilityDisplay(-1);  // 耐久力を減算しない場合はこちらにする
         }
 
         // 使用停止のシェードの設定
@@ -150,22 +155,22 @@ public class BackPackInItem : PoolBase {
         imgReleaseIcon.alphaHitTestMinimumThreshold = 1;
 
         // 交渉成功時
-        //successSettlementDisposable = SymbolManager.instance.onSuccessSettlement
-        //    .Subscribe(_ => {
-        //        // パッシブの場合には耐久値を1回分だけ減らす
-        //        // 必ず this で、新しく作成した ItemData を参照する
-        //        if (entityType == EntityType.Player && this.itemData.effectType == EffectType.Passive) {
-        //            this.itemData.durability--;
-        //            if (this.itemData.durability <= 0) {
-        //                UpdateDurabilityDisplay(0);
-        //                AddPriceToMoney(ReleaseType.Destroy);  // 0 だが一応
-        //                Release();
-        //            } else {
-        //                UpdateDurabilityDisplay(this.itemData.durability);
-        //            }
-        //            DebugLogger.Log(this.itemData.durability);
-        //        }
-        //    });
+        successSettlementDisposable = BattleManager.instance.OnSuccessSettlement
+            .Subscribe(_ => {
+                // パッシブの場合には耐久値を1回分だけ減らす
+                // 必ず this で、新しく作成した ItemData を参照する
+                if (entityType == EntityType.Player && this.itemData.effectType == EffectType.Passive) {
+                    this.itemData.durability--;
+                    if (this.itemData.durability <= 0) {
+                        UpdateDurabilityDisplay(0);
+                        AddPriceToMoney(ReleaseType.Destroy);  // 0 だが一応
+                        Release();
+                    } else {
+                        UpdateDurabilityDisplay(this.itemData.durability);
+                    }
+                    DebugLogger.Log(this.itemData.durability);
+                }
+            });
     }
 
     /// <summary>
@@ -216,7 +221,7 @@ public class BackPackInItem : PoolBase {
         //    Debug.Log($"hpBonus : {enhanceItemData.hpBonus}");
         //}
 
-        // 強化回数を加算
+        // 強化回数を加算 = 表示更新の購読処理が動く
         EnhanceLevel.Value += enhanceCount;
 
         battleStartDisposable?.Dispose();
@@ -228,7 +233,7 @@ public class BackPackInItem : PoolBase {
                 ExecuteBackPackItem(itemData, cts.Token, entityType, resultType).Forget();
             });
 
-        //UpdateDurabilityDisplay(itemData.durability);
+        UpdateDurabilityDisplay(itemData.durability);
         DebugLogger.Log("強化");
     }
 
@@ -249,6 +254,7 @@ public class BackPackInItem : PoolBase {
             txtDurability.text = string.Empty;
         }
         else {
+            if (this == null || txtDurability == null) return;
             txtDurability.text = durability.ToString();
         }        
     }
@@ -323,6 +329,7 @@ public class BackPackInItem : PoolBase {
 
                 // 例えば、特定の行動回数のときだけ処理変わる、など (count == 0 なら fillAmount = 0.5f スタートなど。)
 
+                if (this == null || imgIconGauge == null) return;
                 imgIconGauge.fillAmount = 1.0f;
 
                 // バフ、デバフを適用して現在値を算出
@@ -372,18 +379,18 @@ public class BackPackInItem : PoolBase {
                             break;
                     }
                     // 耐久値を減算
-                    //if (entityType == EntityType.Player) {
-                    //    itemData.durability--;
-                    //    if (itemData.durability <= 0) {
-                    //        UpdateDurabilityDisplay(0);
-                    //        AddPriceToMoney(ReleaseType.Destroy);  // 0 だが一応
-                    //        Release();
-                    //        break;
-                    //    } else {
-                    //        UpdateDurabilityDisplay(itemData.durability);
-                    //        //Debug.Log(itemData.durability);
-                    //    }
-                    //}
+                    if (entityType == EntityType.Player) {
+                        itemData.durability--;
+                        if (itemData.durability <= 0) {
+                            UpdateDurabilityDisplay(0);
+                            AddPriceToMoney(ReleaseType.Destroy);  // 0 だが一応
+                            Release();
+                            break;
+                        } else {
+                            UpdateDurabilityDisplay(itemData.durability);
+                            //Debug.Log(itemData.durability);
+                        }
+                    }
 
                     // for 文なのでフレーム跨がせる。そうしないと、ここですべて処理しようとして処理が一時止まる
                     await UniTask.Yield(cancellationToken: token);
@@ -768,5 +775,9 @@ public class BackPackInItem : PoolBase {
         canvasGroupShade.gameObject.SetActive(isDisuse);
 
         UpdateEnhanceLevelDisplay(level);
+    }
+
+    private void OnDestroy() {
+        Release();
     }
 }

--- a/Assets/Scripts/Wodertale/BattleManager.cs
+++ b/Assets/Scripts/Wodertale/BattleManager.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Generic;
-using UnityEngine;
-using Cysharp.Threading.Tasks;
-using System.Threading;
+﻿using Cysharp.Threading.Tasks;
 using R3;
-using System;
-using Unity.Cinemachine;
 using R3.Triggers;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Unity.Cinemachine;
+using UnityEngine;
 
 public enum EntityType {
     Player,
@@ -66,6 +66,8 @@ public class BattleManager : AbstractSingleton<BattleManager> {
     public StageUIManager stageUIManager;
 
     private int enemyMaxHp = 0;
+
+    public Subject<Unit> OnSuccessSettlement = new();  // 交渉成功時の購読用
 
 
     protected override void Awake() {
@@ -146,99 +148,134 @@ public class BattleManager : AbstractSingleton<BattleManager> {
     /// </summary>
     /// <param name="enemySymbol"></param>
     /// <returns></returns>
-    public async UniTask<BattleResultType> StartBattle(EnemyData enemyData, TurnState turnState) {
+    public async UniTask StartBattleAsync(EnemyData enemyData, TurnState turnState) {
         GameData.instance.CurrentGameState.Value = GameData.GameState.Battle;
-
-        // バトル時間設定
-        if(turnState == TurnState.Boss) {
-            BattleDuration.Value = bossBattleTime;
-        } else {
-            BattleDuration.Value = defaultBattleTime;
-        }
-
-        // 新しいトークンソースを生成
-        // 初期化しないと Cancel 状態のままのトークンを利用してしまうため、BackPackItem の処理がスキップされてしまう
-        cts = new CancellationTokenSource();
-        enemyDisposables = new();
-
-        // 敵の装備情報を取得
-        List<int> equipItemNoList = enemyData.GetEquipItemNoList();
-
-        // 敵の情報表示。未討伐の場合にはシェードをかけたり、名前を不確定名にする
-        EnemyInfoDisplayManager.instance.ShowEnemyInfo(enemyData, equipItemNoList, GameData.GameState.Battle);
-
-        enemyMaxHp = enemyData.hp;
-
-        // 敵の Hp 表示更新
-        EnemyHP.Value = enemyData.hp;
-
-        EnemyHP
-            .Zip(EnemyHP.Skip(1), (oldValue, newValue) => (oldValue, newValue))
-            .Subscribe(hp => {
-                EnemyInfoDisplayManager.instance.UpdateDisplayEnemyHp(hp.oldValue, hp.newValue);
-                CheckEndCondition();
-            }).AddTo(enemyDisposables);
-
-        // 敵のシールド 表示更新
-        EnemyShieldHP.Value = enemyData.shieldPower;
-
-        EnemyShieldHP
-            .Subscribe(shield => {
-                // UI 更新
-                EnemyInfoDisplayManager.instance.UpdateEnemyShieldHp(shield);
-             }).AddTo(enemyDisposables);
-
         battleResultType = BattleResultType.Battle;
 
-        // 都度 cts を渡さないと外部では連動して停止しない
-        OnBattleStart.OnNext((cts, battleResultType));
-        //Debug.Log("StartBattle");
+        // ボス以外は交渉の判定
+        if (turnState != TurnState.Boss) {
+            float settlementRate = PlayerInventoryManager.instance.GetSettlementRate();
+            DebugLogger.Log($"settlementRate : {settlementRate}");
 
-        // バトルエフェクトの表示と再生
-        battleEffectSetObj.SetActive(true);
-        StartBattleShake(amplitude, frequency);
+            float settlementBonus = GameData.instance.charaStatus.GetReactionBonusRate(StatusType.Charm);
+            DebugLogger.Log($"settlementBonus : {settlementBonus}");
 
-        // バトル制限時間を管理するタスクを開始
-        ManageBattleDuration((int)BattleDuration.Value, cts.Token).Forget();
+            float randomSettlementValue = UnityEngine.Random.Range(0, 100.00f);
+            DebugLogger.Log($"settlement randomValue : {randomSettlementValue}");
 
-        float interval = 0.2f; // SEを再生する間隔（秒）
-        float timer = 0; ;
+            // 合計
+            settlementRate += settlementBonus;
 
-        // バトル時間の計測開始
-        IDisposable updateSubscribe = this.UpdateAsObservable()
-            .Where(_ => !cts.IsCancellationRequested)
-            .Where(_ => BattleDuration.Value > 0)
-            .Subscribe(_ => {
-                BattleDuration.Value -= Time.deltaTime;
-                timer += Time.deltaTime;
+            // 交渉成功時にはバトルなし
+            if (randomSettlementValue <= settlementRate) {
+                battleResultType = BattleResultType.Win;
 
-                if (timer >= interval) {
-                    timer = 0;
+                // 耐久力減少(Backpack 側で購読)
+                OnSuccessSettlement.OnNext(Unit.Default);
 
-                    int seIndex = UnityEngine.Random.Range(0, 5);
-                    // SEを再生
-                    SoundManager.instance.PlaySE((SE_TYPE)seIndex);
-                    DebugLogger.Log("SE");
-                }
-            });
+                // 交渉成功のメッセージ表示
+                stageUIManager.SuccessSettlementInfo();
+            }
+        }
 
-        channel = Channel.CreateSingleConsumerUnbounded<BattleResultType>();
-        battleResultType = await channel.Reader.ReadAsync();
+        // 交渉に成功してない敵、あるいはボスの場合
+        if (battleResultType == BattleResultType.Battle) {
 
-        channel.Writer.TryComplete();
-        updateSubscribe?.Dispose();
+            // バトル時間設定
+            if (turnState == TurnState.Boss) {
+                BattleDuration.Value = bossBattleTime;
+            } else {
+                BattleDuration.Value = defaultBattleTime;
+            }
 
-        await UniTask.Delay(1000);
+            // 新しいトークンソースを生成
+            // 初期化しないと Cancel 状態のままのトークンを利用してしまうため、BackPackItem の処理がスキップされてしまう
+            cts = new CancellationTokenSource();
+            enemyDisposables = new();
 
-        EnemyInfoDisplayManager.instance.HideEnemyInfo();
+            // 敵の装備情報を取得
+            List<int> equipItemNoList = enemyData.GetEquipItemNoList();
 
-        PlayerShieldHP.Value = 0;
-        EnemyShieldHP.Value = 0;
+            // 敵の情報表示。未討伐の場合にはシェードをかけたり、名前を不確定名にする
+            EnemyInfoDisplayManager.instance.ShowEnemyInfo(enemyData, equipItemNoList, GameData.GameState.Battle);
 
-        //updateSubscribe?.Dispose();
+            enemyMaxHp = enemyData.hp;
 
-        //GameData.instance.gameState.Value = GameData.GameState.Play;
-        return battleResultType;
+            // 敵の Hp 表示更新
+            EnemyHP.Value = enemyData.hp;
+
+            EnemyHP
+                .Zip(EnemyHP.Skip(1), (oldValue, newValue) => (oldValue, newValue))
+                .Subscribe(hp => {
+                    EnemyInfoDisplayManager.instance.UpdateDisplayEnemyHp(hp.oldValue, hp.newValue);
+                    CheckEndCondition();
+                }).AddTo(enemyDisposables);
+
+            // 敵のシールド 表示更新
+            EnemyShieldHP.Value = enemyData.shieldPower;
+
+            EnemyShieldHP
+                .Subscribe(shield => {
+                    // UI 更新
+                    EnemyInfoDisplayManager.instance.UpdateEnemyShieldHp(shield);
+                }).AddTo(enemyDisposables);
+
+            battleResultType = BattleResultType.Battle;
+
+            // 都度 cts を渡さないと外部では連動して停止しない
+            OnBattleStart.OnNext((cts, battleResultType));
+            //Debug.Log("StartBattle");
+
+            // バトルエフェクトの表示と再生
+            battleEffectSetObj.SetActive(true);
+            StartBattleShake(amplitude, frequency);
+
+            // バトル制限時間を管理するタスクを開始
+            ManageBattleDuration((int)BattleDuration.Value, cts.Token).Forget();
+
+            float interval = 0.2f; // SEを再生する間隔（秒）
+            float timer = 0; ;
+
+            // バトル時間の計測開始
+            IDisposable updateSubscribe = this.UpdateAsObservable()
+                .Where(_ => !cts.IsCancellationRequested)
+                .Where(_ => BattleDuration.Value > 0)
+                .Subscribe(_ => {
+                    BattleDuration.Value -= Time.deltaTime;
+                    timer += Time.deltaTime;
+
+                    if (timer >= interval) {
+                        timer = 0;
+
+                        int seIndex = UnityEngine.Random.Range(0, 5);
+                        // SEを再生
+                        SoundManager.instance.PlaySE((SE_TYPE)seIndex);
+                        DebugLogger.Log("SE");
+                    }
+                });
+
+            channel = Channel.CreateSingleConsumerUnbounded<BattleResultType>();
+            battleResultType = await channel.Reader.ReadAsync();
+
+            channel.Writer.TryComplete();
+            updateSubscribe?.Dispose();
+
+            DebugLogger.Log($"battleResultType : {battleResultType}");
+
+            await UniTask.Delay(1000);
+
+            EnemyInfoDisplayManager.instance.HideEnemyInfo();
+
+            PlayerShieldHP.Value = 0;
+            EnemyShieldHP.Value = 0;
+
+            //updateSubscribe?.Dispose();
+
+            //GameData.instance.gameState.Value = GameData.GameState.Play;
+
+        }
+
+        await BattleResultAsync(enemyData);
     }
 
     /// <summary>
@@ -262,10 +299,57 @@ public class BattleManager : AbstractSingleton<BattleManager> {
         // カメラとマスクの制御　元に戻す
         StopBattleShake();
 
+        if (this == null || battleEffectSetObj == null) return;
+
         // バトルエフェクト非表示
         battleEffectSetObj.SetActive(false);
 
         channel.Writer.TryWrite(battleResultType);
+    }
+
+    private async UniTask BattleResultAsync(EnemyData enemyData) {
+
+        // バトル結果が勝利の場合
+        if (battleResultType == BattleResultType.Win) {
+            // 討伐した敵を登録
+            GameData.instance.AddDefeatEnemyList(enemyData.enemyNo);
+
+            // 経験値獲得
+            GameData.instance.userData.SoulPoint.Value += enemyData.exp;
+
+            // 敵のレアリティから同レアリティのアイテムテータを抽選
+            ItemData itemData = DataBaseManager.instance.GetRandomItemByEnemyDrop(enemyData.rarity);
+
+            // カードの種類とマスターデータを設定
+            CardData cardData = new() {
+                cardTypeMaster = DataBaseManager.instance.GetCardType(CardEventType.TreasureChest),
+                masterData = itemData
+            };
+
+            // 不要なアイテムを破棄できるようにステートを戻しておく
+            GameData.instance.CurrentGameState.Value = GameData.GameState.Play;
+
+            // 宝箱カードの生成、カードの効果を実行
+            TreasureChestCard treasureChestCard = new(cardData, true);
+
+            if (cts.IsCancellationRequested) {
+                return;
+            }
+            
+            await treasureChestCard.ExecuteCardAsync(cts.Token);
+        } else if (battleResultType == BattleResultType.Lose) {
+            DebugLogger.Log($"Game Over");
+            GameData.instance.CurrentGameState.Value = GameData.GameState.GameUp;
+
+            SoundManager.instance.PlayVoice(VOICE_TYPE.Loose);
+            //stageUIManager.ShowRestartMessage();
+
+            await UniTask.WaitUntil(() => UnityEngine.Input.GetMouseButtonDown(0), cancellationToken: cts.Token);
+            SceneStateManager.instance.PrepareteNextScene(SceneName.Title);
+        } else if (battleResultType == BattleResultType.Timeout) {
+            DebugLogger.Log($"Timeout");
+            GameData.instance.CurrentGameState.Value = GameData.GameState.Play;
+        }
     }
 
 

--- a/Assets/Scripts/Wodertale/EnemyInfoDisplayManager.cs
+++ b/Assets/Scripts/Wodertale/EnemyInfoDisplayManager.cs
@@ -49,8 +49,9 @@ public class EnemyInfoDisplayManager : AbstractSingleton<EnemyInfoDisplayManager
         // 引数で、敵の情報(Hp、バフ、デバフ、装備品)をもらって設定する
 
         // 名前設定
-        NameData nameData = DataBaseManager.instance.GetRandomNameData();
-        txtName.text = nameData.name;
+        //NameData nameData = DataBaseManager.instance.GetRandomNameData();
+        //txtName.text = nameData.name;
+        txtName.text = "";
 
         // アイコン画像の設定
         Sprite enemyIcon = DataBaseManager.instance.GetEnemyIcon(enemyData.enemyNo);

--- a/Assets/Scripts/Wodertale/ItemHoverUI.cs
+++ b/Assets/Scripts/Wodertale/ItemHoverUI.cs
@@ -24,7 +24,7 @@ public class ItemHoverUI : MonoBehaviour
         //    return;
         //}
 
-        if(backPackInItem == null || backPackInItem.itemData == null) {
+        if (backPackInItem == null || backPackInItem.itemData == null) {
             return;
         }
         

--- a/Assets/Scripts/Wodertale/ItemInfoDisplayManager.cs
+++ b/Assets/Scripts/Wodertale/ItemInfoDisplayManager.cs
@@ -33,10 +33,12 @@ public class ItemInfoDisplayManager : AbstractSingleton<ItemInfoDisplayManager> 
     public bool isTreasureShow;
 
 
-    //void Start() {
-    //    // 最初からインスペクターでアルファ 0 にしておく
-    //    HideItemInfo();
-    //}
+    protected override void Awake() {
+        base.Awake();
+        HideItemInfo();
+        cgFilter.blocksRaycasts = false;
+        cgFilter.alpha = 0f;
+    }
 
     /// <summary>
     /// ホバーしたアイテムの情報表示
@@ -132,16 +134,21 @@ public class ItemInfoDisplayManager : AbstractSingleton<ItemInfoDisplayManager> 
             itemInfoSet.localPosition = enemyItemTran.localPosition;
         }
 
-        if (itemInfoCanvas != null) {
-            itemInfoCanvas.alpha = 1.0f;
-        }
+        ShowItemInfo();
     }
 
+    public void ShowItemInfo() {
+        if (this == null || itemInfoCanvas == null) {
+            return;
+        }
+        itemInfoCanvas.alpha = 1.0f;
+    }
 
     public void HideItemInfo() {
-        if (itemInfoCanvas != null) {
-            itemInfoCanvas.alpha = 0;
+        if (this == null || itemInfoCanvas == null) {
+            return;
         }
+        itemInfoCanvas.alpha = 0;
     }
 
     /// <summary>
@@ -276,17 +283,19 @@ public class ItemInfoDisplayManager : AbstractSingleton<ItemInfoDisplayManager> 
 
         await UniTask.Delay(1000);
 
-        itemInfoCanvas.alpha = 1.0f;
+        ShowItemInfo();
 
         // 画面タップするまで待機(ほかの UI には触らないようにする)
         bool isTouch = false;
         cgFilter.blocksRaycasts = true;
+        cgFilter.alpha = 1.0f;
         disposable = btnFilter.OnClickExt(() => isTouch = true, this);
 
         await UniTask.WaitUntil(() => isTouch == true, cancellationToken: token);
 
         disposable.Dispose();
         cgFilter.blocksRaycasts = false;
+        cgFilter.alpha = 0f;
 
         isTreasureShow = false;
         HideItemInfo();

--- a/Assets/Scripts/Wodertale/PlayerInventoryManager.cs
+++ b/Assets/Scripts/Wodertale/PlayerInventoryManager.cs
@@ -422,6 +422,10 @@ public class PlayerInventoryManager : AbstractSingleton<PlayerInventoryManager> 
         txtSettle.text = (itemTotalSettleRate + bonusSettleRate).ToString("F2");
     }
 
+    private void OnDestory() {
+        disposables?.Clear();
+    }
+
     // 他のインベントリ関連のメソッドを追加
 
 }

--- a/Assets/Scripts/Wodertale/StageUIManager.cs
+++ b/Assets/Scripts/Wodertale/StageUIManager.cs
@@ -21,6 +21,7 @@ public class StageUIManager : MonoBehaviour {
     [SerializeField] private Text txtWaveInfo;
     [SerializeField] private Text txtInventoryMaxInfo;
     [SerializeField] private Text txtRestartMessage;
+    [SerializeField] private Text txtSettlementInfo;    // 画面優先順位の関係上、Canvas_ItemInfo オブジェクト内にあるオブジェクトを使う
 
     [SerializeField] private Slider sliderHp;
 
@@ -35,6 +36,10 @@ public class StageUIManager : MonoBehaviour {
     [SerializeField] private Sprite[] stateSprites;    // Win,Loose,Timeout の順番
     [SerializeField] private Image inventoryFilter;
 
+    [SerializeField] private Color releaseMessageColor;
+    [SerializeField] private CircleOutline circleOutline;
+
+    private string SuccessSettlementMessage = "平和的解決に成功しました!!";
     private float defaultTime;
 
     public Transform playerBackPackItemTran;
@@ -245,6 +250,20 @@ public class StageUIManager : MonoBehaviour {
         sequence.SetLink(gameObject);
         sequence.Append(txtInventoryMaxInfo.DOFade(1.0f, 1.0f).SetEase(Ease.Linear)).SetLoops(2, LoopType.Yoyo);
         sequence.Append(txtInventoryMaxInfo.DOFade(0f, 0.5f).SetEase(Ease.Linear)).OnComplete(() => txtInventoryMaxInfo.DOFade(0f, 0f));  // 消えないことがあるので念のため
+    }
+
+    /// <summary>
+    /// 交渉に成功したときのメッセージ表示
+    /// </summary>
+    public void SuccessSettlementInfo() {
+        circleOutline.SetEffectColor(releaseMessageColor);
+        txtSettlementInfo.text = SuccessSettlementMessage;
+
+        // 点滅させて表示
+        Sequence sequence = DOTween.Sequence();
+        sequence.SetLink(gameObject);
+        sequence.Append(txtSettlementInfo.DOFade(1.0f, 1.0f).SetEase(Ease.Linear)).SetLoops(2, LoopType.Yoyo);
+        sequence.Append(txtSettlementInfo.DOFade(0f, 0.5f).SetEase(Ease.Linear)).OnComplete(() => txtSettlementInfo.DOFade(0f, 0f));  // 消えないことがあるので念のため
     }
 
     /// <summary>

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,6 +6,9 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
+    path: Assets/Scenes/Title.unity
+    guid: 321b9acbee802e94b99387ec4cb0767a
+  - enabled: 1
     path: Assets/Scenes/Stage.unity
     guid: 2cda990e2423bbf4892e6590ba056729
   m_configObjects: {}


### PR DESCRIPTION
・交渉の購読処理を復帰。
・リトライボタンを追加。その際、オブジェクトプールの処理が不具合を起こしたので修正。

・アイテムアイコンのサイズを調整し、横に4つ並ぶようにした。
　インベントリ内の縦スペースを広くして、各リリースボタンを押せるように調整。

・強化レベルの初期化が抜けていたので追加(＋X の表示がずれていた不具合が修正された) 
・耐久力の処理を復活。

・アイテムの破棄がアイテム入手時にもできるようにした。
・敵の名前表示を一旦削除。