### PR TITLE
インベントリの拡張機能を、XP 消費型として追加。

### DIFF
--- a/Assets/Editor/RaycastPaddingEditor.cs
+++ b/Assets/Editor/RaycastPaddingEditor.cs
@@ -1,0 +1,49 @@
+﻿using UnityEditor;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Image コンポーネントの RaycastPadding を可視化するエディター拡張
+/// </summary>
+public class RaycastPaddingEditor {
+    [DrawGizmo(GizmoType.Selected)]
+    private static void DrawImageRaycastPaddingGizmos(Image image, GizmoType gizmoType) {
+        var color = Color.red;
+
+        Gizmos.color = color;
+
+        var rt = image.rectTransform;
+        var positions = new Vector3[4];
+        var rect = GetRect(image.rectTransform);
+        var pad = image.raycastPadding;
+        positions[0] = new Vector3(rect.x + pad.x, rect.y + pad.y);
+        positions[1] = new Vector3(rect.x + rect.width - pad.z, rect.y + pad.y);
+        positions[2] = new Vector3(rect.x + rect.width - pad.z, rect.y + rect.height - pad.w);
+        positions[3] = new Vector3(rect.x + pad.x, rect.y + rect.height - pad.w);
+
+        for (int i = 0; i < positions.Length; i++) {
+            //Debug.Log($"name= {image.gameObject.name} : {positions[i]}");
+        }
+
+        if (image.raycastTarget) {
+            Gizmos.DrawLine(positions[0], positions[1]);
+            Gizmos.DrawLine(positions[1], positions[2]);
+            Gizmos.DrawLine(positions[2], positions[3]);
+            Gizmos.DrawLine(positions[3], positions[0]);
+        }
+    }
+
+    public static Rect GetRect(RectTransform rectTransform) {
+        Vector2 size = rectTransform.rect.size;
+        size.x *= rectTransform.lossyScale.x;
+        size.y *= rectTransform.lossyScale.y;
+
+        return new Rect {
+            center = (Vector2)rectTransform.position - new Vector2(
+                rectTransform.pivot.x * size.x,
+                rectTransform.pivot.y * size.y
+            ),
+            size = size,
+        };
+    }
+}

--- a/Assets/Editor/RaycastPaddingEditor.cs.meta
+++ b/Assets/Editor/RaycastPaddingEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: de96a7ecc772584498a0c3910e62c971

--- a/Assets/Joystick Pack/Sprites/Horizontal Backgrounds/Horizontal_Plain.png.meta
+++ b/Assets/Joystick Pack/Sprites/Horizontal Backgrounds/Horizontal_Plain.png.meta
@@ -3,7 +3,7 @@ guid: 097782735540f2d4db5606eae04ae6a7
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 11
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -20,10 +20,12 @@ TextureImporter:
     externalNormalMap: 0
     heightScale: 0.25
     normalMapFilter: 0
+    flipGreenChannel: 0
   isReadable: 0
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
+  ignoreMipmapLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -32,12 +34,12 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: -1
-    aniso: -1
-    mipBias: -100
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
     wrapU: 1
     wrapV: 1
-    wrapW: -1
+    wrapW: 0
   nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
@@ -47,7 +49,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 100
-  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteBorder: {x: 100, y: 240, z: 100, w: 240}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -62,8 +64,10 @@ TextureImporter:
   textureFormatSet: 0
   ignorePngGamma: 0
   applyGammaDecoding: 1
+  swizzle: 50462976
+  cookieLightType: 1
   platformSettings:
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -73,9 +77,10 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 1
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -85,10 +90,11 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 1
-  - serializedVersion: 3
-    buildTarget: iPhone
+  - serializedVersion: 4
+    buildTarget: iOS
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
@@ -97,9 +103,10 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 1
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Android
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -109,9 +116,10 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 1
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: WebGL
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -121,24 +129,28 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 1
   spriteSheet:
     serializedVersion: 2
     sprites: []
     outline: []
+    customData: 
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 0
+    internalID: 1537655665
     vertices: []
     indices: 
     edges: []
     weights: []
     secondaryTextures: []
-  spritePackingTag: 
+    spriteCustomMetadata:
+      entries: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
   pSDRemoveMatte: 0
-  pSDShowRemoveMatteOption: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Scenes/Stage.unity
+++ b/Assets/Scenes/Stage.unity
@@ -119,6 +119,102 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &326303
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 326304}
+  - component: {fileID: 326307}
+  - component: {fileID: 326306}
+  - component: {fileID: 326305}
+  m_Layer: 5
+  m_Name: txtSizeInfo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &326304
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 326303}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.3, y: 0.3, z: 0.3}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 1769964953}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -1.7, y: 0}
+  m_SizeDelta: {x: 500, y: 160}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &326305
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 326303}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f2de2aacacc5ac4a8971717bc37f923, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0.009433985, g: 0.009433985, b: 0.009433985, a: 0.5}
+  m_EffectDistance: 3
+  m_nEffectNumber: 8
+  m_UseGraphicAlpha: 1
+--- !u!114 &326306
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 326303}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 0f31f6677d7535e4ca2a1196b4d4f973, type: 3}
+    m_FontSize: 80
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 300
+    m_Alignment: 5
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 200
+--- !u!222 &326307
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 326303}
+  m_CullTransparentMesh: 1
 --- !u!1 &8618922
 GameObject:
   m_ObjectHideFlags: 0
@@ -967,7 +1063,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -733, y: -465}
+  m_AnchoredPosition: {x: 705, y: -465}
   m_SizeDelta: {x: 103, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &107718663
@@ -3270,6 +3366,7 @@ MonoBehaviour:
   txtMemoriaRank: {fileID: 1263349291}
   debugFlipPoint: 20
   debugFloorClearBonusFlipPoint: 5
+  debugComboBonusRate: 10
 --- !u!1 &268425037
 GameObject:
   m_ObjectHideFlags: 0
@@ -3987,6 +4084,7 @@ RectTransform:
   - {fileID: 1644333517}
   - {fileID: 1972840755}
   - {fileID: 107718664}
+  - {fileID: 1349598667}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -4039,6 +4137,102 @@ RectTransform:
   m_AnchoredPosition: {x: -232, y: 285}
   m_SizeDelta: {x: 330, y: 220}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &333910810
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 333910811}
+  - component: {fileID: 333910813}
+  - component: {fileID: 333910814}
+  - component: {fileID: 333910812}
+  m_Layer: 5
+  m_Name: txtComboPairCount
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &333910811
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 333910810}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.40000004, y: 0.40000004, z: 0.40000004}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 625249512}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.00044823, y: 0}
+  m_SizeDelta: {x: 144.75, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &333910812
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 333910810}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f2de2aacacc5ac4a8971717bc37f923, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
+  m_EffectDistance: 2
+  m_nEffectNumber: 8
+  m_UseGraphicAlpha: 1
+--- !u!222 &333910813
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 333910810}
+  m_CullTransparentMesh: 1
+--- !u!114 &333910814
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 333910810}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: e5ce7090eff7556438a6272f66c46d74, type: 3}
+    m_FontSize: 100
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 125
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 0
 --- !u!1 &335423285
 GameObject:
   m_ObjectHideFlags: 0
@@ -5480,6 +5674,81 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 513142840}
   m_CullTransparentMesh: 1
+--- !u!1 &516913857
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 516913858}
+  - component: {fileID: 516913860}
+  - component: {fileID: 516913859}
+  m_Layer: 5
+  m_Name: imgBackpack
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &516913858
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 516913857}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 746502784}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 46.7}
+  m_SizeDelta: {x: 60, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &516913859
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 516913857}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 8710c44739980ae4db874557f795c531, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &516913860
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 516913857}
+  m_CullTransparentMesh: 1
 --- !u!1 &521237670
 GameObject:
   m_ObjectHideFlags: 0
@@ -6263,6 +6532,82 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 616660700}
+  m_CullTransparentMesh: 1
+--- !u!1 &625249511
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 625249512}
+  - component: {fileID: 625249514}
+  - component: {fileID: 625249513}
+  m_Layer: 5
+  m_Name: imgComboFrame
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &625249512
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625249511}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 333910811}
+  m_Father: {fileID: 1162225600}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 31.36, y: -1.0249991}
+  m_SizeDelta: {x: 57.9, y: 59.95}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &625249513
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625249511}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.61960787}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300012, guid: 34ecf51bcd3f4424eafda7dafd885bd0, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &625249514
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625249511}
   m_CullTransparentMesh: 1
 --- !u!1 &627972488
 GameObject:
@@ -7226,6 +7571,87 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 730582227}
+  m_CullTransparentMesh: 1
+--- !u!1 &746502783
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 746502784}
+  - component: {fileID: 746502786}
+  - component: {fileID: 746502785}
+  m_Layer: 5
+  m_Name: imgFrame
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &746502784
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 746502783}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 960019334}
+  - {fileID: 516913858}
+  - {fileID: 825866588}
+  - {fileID: 1769964953}
+  - {fileID: 1811452962}
+  - {fileID: 1399035409}
+  m_Father: {fileID: 1349598667}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 300, y: 300}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &746502785
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 746502783}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.8156863}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300058, guid: 34ecf51bcd3f4424eafda7dafd885bd0, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &746502786
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 746502783}
   m_CullTransparentMesh: 1
 --- !u!1 &751586283
 GameObject:
@@ -8208,6 +8634,102 @@ MonoBehaviour:
     m_LineSpacing: 1.45
   m_Text: "\u3042\u308B\u3044\u306F\u4EE5\u4E0B\u306E\u80FD\u529B\u5024\u304C\n\u6307\u5B9A\u5024\u4EE5\u4E0A\u3067\u3042\u308C\u3070\u30D1\u30EF\u30FC\u30B9\u30DD\u30C3\u30C8\u89E3\u653E\nReleasePoint
     : \nReleasePoint : \nReleasePoint : "
+--- !u!1 &825866587
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 825866588}
+  - component: {fileID: 825866591}
+  - component: {fileID: 825866590}
+  - component: {fileID: 825866589}
+  m_Layer: 5
+  m_Name: txtNextSize
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &825866588
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 825866587}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.3, y: 0.3, z: 0.3}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 746502784}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -5.5, y: -18.1}
+  m_SizeDelta: {x: 800, y: 160}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &825866589
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 825866587}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f2de2aacacc5ac4a8971717bc37f923, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0.009433985, g: 0.009433985, b: 0.009433985, a: 0.5}
+  m_EffectDistance: 3
+  m_nEffectNumber: 12
+  m_UseGraphicAlpha: 1
+--- !u!114 &825866590
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 825866587}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 0f31f6677d7535e4ca2a1196b4d4f973, type: 3}
+    m_FontSize: 100
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 300
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 10 >>> 11
+--- !u!222 &825866591
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 825866587}
+  m_CullTransparentMesh: 1
 --- !u!1 &830775970
 GameObject:
   m_ObjectHideFlags: 0
@@ -9444,6 +9966,102 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1.25
   m_Text: 
+--- !u!1 &960019333
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 960019334}
+  - component: {fileID: 960019337}
+  - component: {fileID: 960019336}
+  - component: {fileID: 960019335}
+  m_Layer: 5
+  m_Name: lblTitle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &960019334
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 960019333}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.3, y: 0.3, z: 0.3}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 746502784}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -24, y: 112.9}
+  m_SizeDelta: {x: 900, y: 160}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &960019335
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 960019333}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f2de2aacacc5ac4a8971717bc37f923, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0.6253116, g: 0.6093508, b: 0.99371064, a: 0.5}
+  m_EffectDistance: 3
+  m_nEffectNumber: 8
+  m_UseGraphicAlpha: 1
+--- !u!114 &960019336
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 960019333}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 0f31f6677d7535e4ca2a1196b4d4f973, type: 3}
+    m_FontSize: 80
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 300
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u30A4\u30F3\u30D9\u30F3\u30C8\u30EA\u62E1\u5F35"
+--- !u!222 &960019337
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 960019333}
+  m_CullTransparentMesh: 1
 --- !u!1 &962059159
 GameObject:
   m_ObjectHideFlags: 0
@@ -12027,6 +12645,7 @@ RectTransform:
   - {fileID: 2033560241}
   - {fileID: 249478005}
   - {fileID: 992013797}
+  - {fileID: 625249512}
   m_Father: {fileID: 6985294761353623262}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -13141,6 +13760,55 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1341774903}
   m_CullTransparentMesh: 1
+--- !u!1 &1349598666
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1349598667}
+  - component: {fileID: 1349598668}
+  m_Layer: 5
+  m_Name: ExpandInventorySizeSet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1349598667
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1349598666}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 746502784}
+  m_Father: {fileID: 295031296}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -351, y: 209}
+  m_SizeDelta: {x: 300, y: 300}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!225 &1349598668
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1349598666}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &1355433100
 GameObject:
   m_ObjectHideFlags: 0
@@ -13461,6 +14129,81 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1395689877}
+  m_CullTransparentMesh: 1
+--- !u!1 &1399035408
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1399035409}
+  - component: {fileID: 1399035411}
+  - component: {fileID: 1399035410}
+  m_Layer: 5
+  m_Name: imgSoul
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1399035409
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1399035408}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 746502784}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -65, y: -75.6}
+  m_SizeDelta: {x: 60, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1399035410
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1399035408}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: cd4f0ac7592f1d2419fda611a409d6f8, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1399035411
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1399035408}
   m_CullTransparentMesh: 1
 --- !u!1 &1416203353
 GameObject:
@@ -16108,6 +16851,12 @@ MonoBehaviour:
   txtAbsorb: {fileID: 791524536}
   txtReflect: {fileID: 730582230}
   txtSettle: {fileID: 1837386314}
+  txtNextSize: {fileID: 825866590}
+  txtSizeInfo: {fileID: 326306}
+  btnShowExpandInventoryPop: {fileID: 1989763077}
+  btnSubmitExpandInventorySize: {fileID: 1769964954}
+  btnCloseExpandInventoryPop: {fileID: 1811452963}
+  cgExpandInventorySizePop: {fileID: 1349598668}
   enhanceRates: 
 --- !u!4 &1599291614
 Transform:
@@ -16923,6 +17672,7 @@ GameObject:
   - component: {fileID: 1699756564}
   - component: {fileID: 1699756566}
   - component: {fileID: 1699756565}
+  - component: {fileID: 1699756567}
   m_Layer: 5
   m_Name: Image
   m_TagString: Untagged
@@ -16964,7 +17714,7 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_RaycastPadding: {x: 0, y: 0, z: -116, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -16987,6 +17737,50 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1699756563}
   m_CullTransparentMesh: 1
+--- !u!114 &1699756567
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1699756563}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1699756565}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &1701413619
 GameObject:
   m_ObjectHideFlags: 0
@@ -17819,6 +18613,7 @@ MonoBehaviour:
   txtUncurseCount: {fileID: 0}
   txtSoulPoint: {fileID: 992013799}
   imgSoulIcon: {fileID: 249478006}
+  txtComboPairCount: {fileID: 333910814}
   txtWaveInfo: {fileID: 0}
   txtInventoryMaxInfo: {fileID: 1953483849}
   txtRestartMessage: {fileID: 107718666}
@@ -17928,6 +18723,127 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1769330418}
+  m_CullTransparentMesh: 1
+--- !u!1 &1769964952
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1769964953}
+  - component: {fileID: 1769964956}
+  - component: {fileID: 1769964955}
+  - component: {fileID: 1769964954}
+  m_Layer: 5
+  m_Name: btnSubmitExpandInventorySize
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1769964953
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1769964952}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 326304}
+  m_Father: {fileID: 746502784}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -83.1}
+  m_SizeDelta: {x: 200, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1769964954
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1769964952}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1769964955}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1769964955
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1769964952}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.112118244, g: 1, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 888feb4a32e3b564fb7e6f9b28cc8e10, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1769964956
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1769964952}
   m_CullTransparentMesh: 1
 --- !u!1 &1774259258
 GameObject:
@@ -18278,6 +19194,126 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 
+--- !u!1 &1811452961
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1811452962}
+  - component: {fileID: 1811452965}
+  - component: {fileID: 1811452964}
+  - component: {fileID: 1811452963}
+  m_Layer: 5
+  m_Name: btnCloseExpandInventoryPop
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1811452962
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1811452961}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 746502784}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 114.3, y: 114.5}
+  m_SizeDelta: {x: 40, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1811452963
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1811452961}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1811452964}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1811452964
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1811452961}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 3f302b37d4c72954a87f7d7a773b0fb9, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1811452965
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1811452961}
+  m_CullTransparentMesh: 1
 --- !u!1 &1820183016
 GameObject:
   m_ObjectHideFlags: 0
@@ -23081,7 +24117,6 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 4612298743309605528}
-  - {fileID: 3318370204847746856}
   - {fileID: 3911603869827923754}
   - {fileID: 974986944}
   - {fileID: 1316073536}
@@ -23089,7 +24124,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 758, y: -197}
+  m_AnchoredPosition: {x: -681, y: -197}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2609833168912613460
@@ -23423,11 +24458,11 @@ RectTransform:
   m_LocalScale: {x: -1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 2300520825423322828}
+  m_Father: {fileID: 6985294761353623262}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -39, y: -22}
+  m_AnchoredPosition: {x: 716, y: -190}
   m_SizeDelta: {x: 300, y: 300}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &3332258711609959592
@@ -24030,6 +25065,7 @@ RectTransform:
   - {fileID: 2129386118}
   - {fileID: 331545396}
   - {fileID: 1536477977}
+  - {fileID: 3318370204847746856}
   - {fileID: 2300520825423322828}
   - {fileID: 31876144}
   - {fileID: 79316844}

--- a/Assets/Scenes/Title.unity
+++ b/Assets/Scenes/Title.unity
@@ -2127,6 +2127,7 @@ MonoBehaviour:
         value: 1
       MemoriaRank:
         value: 0
+      expandInventoryCount: 0
       SoulPoint:
         value: 0
       WalkCount:
@@ -8788,6 +8789,7 @@ GameObject:
   - component: {fileID: 1449718753}
   - component: {fileID: 1449718752}
   - component: {fileID: 1449718751}
+  - component: {fileID: 1449718754}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -8863,12 +8865,44 @@ Transform:
   m_GameObject: {fileID: 1449718750}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalPosition: {x: 0.00000004635917, y: 0.09549, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1449718754
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1449718750}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72ece51f2901e7445ab60da3685d6b5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.Cinemachine::Unity.Cinemachine.CinemachineBrain
+  ShowDebugText: 0
+  ShowCameraFrustum: 1
+  IgnoreTimeScale: 0
+  WorldUpOverride: {fileID: 0}
+  ChannelMask: -1
+  UpdateMethod: 2
+  BlendUpdateMethod: 1
+  LensModeOverride:
+    Enabled: 0
+    DefaultMode: 2
+  DefaultBlend:
+    Style: 1
+    Time: 2
+    CustomCurve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+  CustomBlends: {fileID: 0}
 --- !u!1 &1476347475
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Datas/BlessingData.cs
+++ b/Assets/Scripts/Datas/BlessingData.cs
@@ -1,5 +1,4 @@
-using RPG_BOX;
-using System;
+﻿using System;
 
 [System.Serializable]
 public class BlessingData : IMasterData {
@@ -9,6 +8,7 @@ public class BlessingData : IMasterData {
     public Rarity rarity;
     public int weight;
     public int exp;
+    public int stack;
 
     public int Id => id;
 
@@ -19,5 +19,6 @@ public class BlessingData : IMasterData {
         rarity = (Rarity)Enum.Parse(typeof(Rarity), datas[3]);
         weight = int.Parse(datas[4]);
         exp = int.Parse(datas[5]);
+        stack = int.Parse(datas[6]);
     }
 }

--- a/Assets/Scripts/Manager/MemoryGameManager.cs
+++ b/Assets/Scripts/Manager/MemoryGameManager.cs
@@ -36,6 +36,7 @@ public class MemoryGameManager : MonoBehaviour {
 
     [SerializeField] private int debugFlipPoint;
     [SerializeField] private int debugFloorClearBonusFlipPoint;
+    [SerializeField] private int debugComboBonusRate;
 
     private readonly Subject<CardView> onCardSelected = new(); // カード選択イベント
     private List<GameObject> slotList = new();                 // スロットを保持
@@ -108,6 +109,8 @@ public class MemoryGameManager : MonoBehaviour {
         // 思い出の秘石獲得時の購読処理
         GameData.instance.userData.MemoryStoneSlotList.ObserveAdd()
             .Subscribe(memoryStoneId => SetMemoryStoneIcon(memoryStoneId.Value)).AddTo(this);
+
+        GameData.instance.ComboPairCount.Subscribe(comboCount => CheckComboEffect(comboCount)).AddTo(this);
 
         // デバッグ用リセット機能
         this.UpdateAsObservable()
@@ -416,6 +419,8 @@ public class MemoryGameManager : MonoBehaviour {
                 if (this == null || selectedCardModel == null || cts == null) return;
                 await selectedCardModel.ExecuteCardAsync(cts.Token);
 
+                GameData.instance.ComboPairCount.Value++;
+
                 // すべてのカードを引き終わっているか確認
                 if (cardModelList.All(model => model.isPair)) {
                     // 次のフロアへ
@@ -433,6 +438,8 @@ public class MemoryGameManager : MonoBehaviour {
 
                 // ペアにならなかったので、めくれる回数の減算
                 GameData.instance.userData.FlipPoint.Value--;
+
+                GameData.instance.ComboPairCount.Value = 0;
             }
 
             firstSelectedCardView = null;
@@ -519,13 +526,17 @@ public class MemoryGameManager : MonoBehaviour {
             // ランクアップ
             GameData.instance.userData.MemoriaRank.Value++;
 
-            // 記憶を取り戻す
+            // TODO 記憶を取り戻す
 
-            // インベントリの上限を超えていないなら
-            if (GameData.instance.playerCombatData.MaxInventorySize.Value < GameData.instance.limitInventorySize) {
-                // インベントリのサイズアップ
-                GameData.instance.playerCombatData.MaxInventorySize.Value++;
-            }            
+
+
+            //// インベントリの上限を超えていないなら
+            //if (GameData.instance.playerCombatData.MaxInventorySize.Value < GameData.instance.limitInventorySize) {
+            //    // インベントリのサイズアップ
+            //    GameData.instance.playerCombatData.MaxInventorySize.Value++;
+            //}
+
+
         }
     }
 
@@ -549,6 +560,27 @@ public class MemoryGameManager : MonoBehaviour {
         }
     }
 
+    /// <summary>
+    /// コンボ時のソウルポイントのボーナス
+    /// </summary>
+    /// <param name="comboCount"></param>
+    private void CheckComboEffect(int comboCount) {
+        if (comboCount == 0) {
+            return;
+        }
+
+        // フロアの階層分のボーナス
+        float floorBonusRate = 0.9f + (float)(GameData.instance.userData.FloorCount.Value * 0.1f);
+        //DebugLogger.Log($"floorBonusRate : {floorBonusRate}");
+
+        int comboBonusPoint = (int)((comboCount - 1) * (debugComboBonusRate * floorBonusRate));
+        if (comboBonusPoint == 0) {
+            return;
+        }
+        //DebugLogger.Log($"comboBonusPoint : {comboBonusPoint}");
+
+        GameData.instance.userData.SoulPoint.Value += comboBonusPoint;
+    }
 
     private async UniTask GameEndAsync() {
         cgSlotSet.blocksRaycasts = false;

--- a/Assets/Scripts/MemoryGame/TreasureChestCard.cs
+++ b/Assets/Scripts/MemoryGame/TreasureChestCard.cs
@@ -45,7 +45,12 @@ public class TreasureChestCard : CardModelBase {
             }
 
             // インベントリにアイテムを追加
-            PlayerInventoryManager.instance.AddItemDataConvertBackPackInItem(itemData, false);
+            if (isEnemyDrop) {
+                // 敵の場合には、1回分の強化を確定
+                PlayerInventoryManager.instance.AddItemDataConvertBackPackInItem(itemData, true);
+            } else {                
+                PlayerInventoryManager.instance.AddItemDataConvertBackPackInItem(itemData, false);
+            }
         }        
 
         await UniTask.Yield(token);

--- a/Assets/Scripts/Wodertale/GameData.cs
+++ b/Assets/Scripts/Wodertale/GameData.cs
@@ -70,6 +70,7 @@ public class GameData : AbstractSingleton<GameData>
     public UserData userData;
 
     public int limitInventorySize = 20;                // 上限値
+    public int expandRequiredXP = 200;                 // インベントリの拡張に必要な基礎値
 
     public CombatData playerCombatData;
     public CombatData enemyCombatData;
@@ -85,8 +86,10 @@ public class GameData : AbstractSingleton<GameData>
     [SerializeField]
     private Transform conditionEffectTran;
 
-    public ReactiveProperty<int> EnchantPoint = new(0);
+    public SerializableReactiveProperty<int> EnchantPoint = new(0);
     public int consumeEnchantPoint;
+
+    public SerializableReactiveProperty<int> ComboPairCount = new(0);
 
 
     //protected override void Awake() {

--- a/Assets/Scripts/Wodertale/ItemInfoDisplayManager.cs
+++ b/Assets/Scripts/Wodertale/ItemInfoDisplayManager.cs
@@ -51,7 +51,12 @@ public class ItemInfoDisplayManager : AbstractSingleton<ItemInfoDisplayManager> 
         //    return;
         //}
 
-        txtName.text = backPackInItem.itemData.itemName;
+        if (backPackInItem.EnhanceLevel.Value > 0) {
+            txtName.text = $"{backPackInItem.itemData.itemName} +{backPackInItem.EnhanceLevel.Value}";
+        } else {
+            txtName.text = $"{backPackInItem.itemData.itemName}";
+        }
+
 
         //txtDesc.text = backPackInItem.currentCoolTime.ToString() + "\n";
         //txtDesc.text += backPackInItem.currentAccuracy.ToString() + "\n";
@@ -109,14 +114,14 @@ public class ItemInfoDisplayManager : AbstractSingleton<ItemInfoDisplayManager> 
         txtDescs[2].text = $"ItemType : {backPackInItem.itemData.itemType}\n\n";
         // Passive のみ HpBonus 表示
         if (backPackInItem.itemData.effectType == EffectType.Passive) {
-            txtDescs[2].text += valueName + " + " + backPackInItem.itemData.hpBonus.ToString() + "\n";            
+            txtDescs[2].text += valueName + " + " + backPackInItem.itemData.hpBonus.ToString() + "\n";
         }
 
         // 各ステータス値
         for (int i = 0; i < backPackInItem.itemData.statusTypes.Length; i++) {
             txtDescs[2].text += backPackInItem.itemData.statusTypes[i].ToString() + " + " + backPackInItem.itemData.requiredValues[i].ToString() + "\n";
         }
-        
+
         //txtDescs[3].text = "Rarity : " + backPackInItem.itemData.rarity.ToString();
         //txtDescs[0].text += backPackInItem.ItemData.Value.description;
 

--- a/Assets/Scripts/Wodertale/PlayerInventoryManager.cs
+++ b/Assets/Scripts/Wodertale/PlayerInventoryManager.cs
@@ -29,6 +29,13 @@ public class PlayerInventoryManager : AbstractSingleton<PlayerInventoryManager> 
     [SerializeField] private Text txtReflect;
     [SerializeField] private Text txtSettle;
 
+    [SerializeField] private Text txtNextSize;                         // 現在のインベントリサイズと次のサイズを表示
+    [SerializeField] private Text txtSizeInfo;                         // 拡張ボタンの上に表示するメッセージ。XP 値か、不足と出す
+    [SerializeField] private Button btnShowExpandInventoryPop;         // バックパックのサイズ部分のボタン。インベントリ拡張ポップを開く
+    [SerializeField] private Button btnSubmitExpandInventorySize;      // インベントリ拡張ボタン
+    [SerializeField] private Button btnCloseExpandInventoryPop;        // インベントリ拡張ポップを閉じるボタン
+    [SerializeField] private CanvasGroup cgExpandInventorySizePop;     // インベントリ拡張ポップの CanvasGroup
+
     [SerializeField] private int[] enhanceRates;
 
     private int orbCount;
@@ -126,6 +133,13 @@ public class PlayerInventoryManager : AbstractSingleton<PlayerInventoryManager> 
 
 
         //GameData.instance.EnchantPoint.Subscribe(point => txtEnchantPoint.text = $"{point:N0}").AddTo(this);
+
+        // インベントリ拡張関連のボタン
+        btnShowExpandInventoryPop.OnClickExt(() => ShowExpandInventorySizePop(), this);
+        btnSubmitExpandInventorySize.OnClickExt(() => ExpandInventorySize(), this);
+        btnCloseExpandInventoryPop.OnClickExt(() => HideExpandInventorySizePop(), this);
+
+        HideExpandInventorySizePop();
     }
 
     /// <summary>
@@ -420,6 +434,71 @@ public class PlayerInventoryManager : AbstractSingleton<PlayerInventoryManager> 
         float itemTotalSettleRate = GetSettlementRate();
         float bonusSettleRate = GameData.instance.charaStatus.GetReactionBonusRate(StatusType.Charm);
         txtSettle.text = (itemTotalSettleRate + bonusSettleRate).ToString("F2");
+    }
+
+    /// <summary>
+    /// インベントリ拡張ポップの表示(表示更新にも使う)
+    /// </summary>
+    public void ShowExpandInventorySizePop() {
+        if (GameData.instance.CurrentGameState.Value != GameData.GameState.Play) {
+            return;
+        }
+
+        cgExpandInventorySizePop.alpha = 1.0f;
+        cgExpandInventorySizePop.blocksRaycasts = true;
+
+        // バックの最大数まで達しているなら
+        if (GameData.instance.playerCombatData.MaxInventorySize.Value >= GameData.instance.limitInventorySize) {
+            txtNextSize.text = $"最大です";
+            txtSizeInfo.color = Color.red;
+            btnSubmitExpandInventorySize.interactable = false;
+            return;
+        }
+        txtNextSize.text = $"{GameData.instance.playerCombatData.MaxInventorySize.Value} >>> {GameData.instance.playerCombatData.MaxInventorySize.Value + 1}";
+
+        // ポイントが足りていないなら
+        int expandRequiredPoint = GameData.instance.expandRequiredXP + (GameData.instance.expandRequiredXP * GameData.instance.userData.expandInventoryCount / 2);
+        if (expandRequiredPoint > GameData.instance.userData.SoulPoint.Value) {
+            txtSizeInfo.text = $"XP 不足";
+            txtSizeInfo.color = Color.red;
+            btnSubmitExpandInventorySize.interactable = false;
+        } else {
+            txtSizeInfo.text = $"{expandRequiredPoint}";
+            txtSizeInfo.color = new(1, 1, 1, 1);
+            btnSubmitExpandInventorySize.interactable = true;
+        }
+    }
+
+    /// <summary>
+    /// インベントリ拡張ポップの非表示
+    /// </summary>
+    public void HideExpandInventorySizePop() {
+        cgExpandInventorySizePop.alpha = 0f;
+        cgExpandInventorySizePop.blocksRaycasts = false;
+    }
+
+    /// <summary>
+    /// インベントリの拡張
+    /// </summary>
+    public void ExpandInventorySize() {
+        // インベントリの上限を超えていないなら
+        if (GameData.instance.playerCombatData.MaxInventorySize.Value < GameData.instance.limitInventorySize) {
+            // インベントリのサイズアップ
+            GameData.instance.playerCombatData.MaxInventorySize.Value++;
+
+            // 消費ポイント計算
+            int expandRequiredPoint = GameData.instance.expandRequiredXP + (GameData.instance.expandRequiredXP * GameData.instance.userData.expandInventoryCount / 2);
+            DebugLogger.Log($"expandRequiredPoint : {expandRequiredPoint}");
+
+            // ポイント消費
+            GameData.instance.userData.SoulPoint.Value -= expandRequiredPoint;
+
+            // 拡張した回数をカウントアップ
+            GameData.instance.userData.expandInventoryCount++;
+
+            // ポップ表示内容更新
+            ShowExpandInventorySizePop();
+        }
     }
 
     private void OnDestory() {

--- a/Assets/Scripts/Wodertale/StageUIManager.cs
+++ b/Assets/Scripts/Wodertale/StageUIManager.cs
@@ -17,6 +17,7 @@ public class StageUIManager : MonoBehaviour {
     [SerializeField] private Text txtUncurseCount;
     [SerializeField] private Text txtSoulPoint;
     [SerializeField] private Image imgSoulIcon;
+    [SerializeField] private Text txtComboPairCount;
 
     [SerializeField] private Text txtWaveInfo;
     [SerializeField] private Text txtInventoryMaxInfo;
@@ -82,6 +83,9 @@ public class StageUIManager : MonoBehaviour {
             .Zip(GameData.instance.userData.SoulPoint.Skip(1), (prevPoint, nextPoint) => (prevPoint, nextPoint))
             .Subscribe(soulPoint => UpdateSoulPoint(soulPoint.prevPoint, soulPoint.nextPoint))
             .AddTo(this);
+
+        // ペアのコンボ回数の購読
+        GameData.instance.ComboPairCount.Subscribe(comboCount => UpdateDisplayComboPairCount(comboCount)).AddTo(this);
     }
 
     /// <summary>
@@ -207,6 +211,14 @@ public class StageUIManager : MonoBehaviour {
 
     private void UpdateDisplayUncurseCount(int count) {
         txtUncurseCount.text = count.ToString();
+    }
+
+    private void UpdateDisplayComboPairCount(int count) {
+        // 現在はデバッグ用の画面右上に出す
+        txtComboPairCount.text = count.ToString();
+
+        // TODO コンボしたときだけ、演出を出す
+
     }
 
     private void UpdateSoulPoint(int prevPoint, int nextPoint) {

--- a/Assets/Scripts/Wodertale/UserData.cs
+++ b/Assets/Scripts/Wodertale/UserData.cs
@@ -10,6 +10,8 @@ public class UserData {
     public SerializableReactiveProperty<int> FloorCount = new(1);
     public SerializableReactiveProperty<int> MemoriaRank = new(0);
 
+    public int expandInventoryCount;                                          // インベントリを拡張した回数
+
     public SerializableReactiveProperty<int> SoulPoint = new();
     public SerializableReactiveProperty<int> WalkCount = new();
     public int stageCount;


### PR DESCRIPTION
・思い出の断片によるサイズアップは削除。

・Stage のプレイヤーの HP 表示位置と思い出の断片の表示位置を交換。

・インベントリボタンを押すと、拡張用のポップアップが開くようにした。

・バックパック内の強化値をアイテムポップアップ内にも表示。