### PR TITLE
めくれる回数減少のトラップ追加。

### DIFF
--- a/Assets/Scripts/Manager/MemoryGameManager.cs
+++ b/Assets/Scripts/Manager/MemoryGameManager.cs
@@ -67,6 +67,7 @@ public class MemoryGameManager : MonoBehaviour {
     private Dictionary<BlessingValueType, (SerializableReactiveProperty<int>, CompositeDisposable)> lookCountMap;
 
     private Subject<Unit> onNextFloor = new();
+    private Subject<Unit> onTurnEnd = new();
     private IDisposable floorCountDisposable;
 
     // デバッグ用
@@ -134,7 +135,7 @@ public class MemoryGameManager : MonoBehaviour {
         GameData.instance.userData.FlipPoint
             .Where(flipPoint => flipPoint <= 0)
             .Take(1)
-            .Subscribe(flipPoint => GameEndAsync().Forget()).AddTo(this);
+            .Subscribe(flipPoint => BattleManager.instance.ForceGameEndAsync().Forget()).AddTo(this);  // GameEndAsync().Forget()
 
         // 思い出の秘石獲得時の購読処理
         GameData.instance.userData.MemoryStoneSlotList.ObserveAdd()
@@ -516,6 +517,9 @@ public class MemoryGameManager : MonoBehaviour {
         if (GameData.instance.userData.CanUseStairs.Value == true) {
             btnStairs.interactable = true;
         }
+
+        // ターン終了を知らせる
+        onTurnEnd.OnNext(default);
     }
 
     public IMasterData CreateCardData(CardEventType type, FloorData floorData) {

--- a/Assets/Scripts/MemoryGame/Trap/DamageTrapExecutor.cs
+++ b/Assets/Scripts/MemoryGame/Trap/DamageTrapExecutor.cs
@@ -37,14 +37,11 @@ public class DamageTrapExecutor : ITrap {
             BattleManager.instance.UpdatePlayerHp(-damage, EffectType.Physical, false);
         }
 
+        // Hp が 0 になったらゲームオーバー
         if (BattleManager.instance.PlayerHP.Value <= 0) {
-            StageUIManager stageUIManager = GameObject.FindFirstObjectByType<StageUIManager>();
-            stageUIManager.ShowBattleState(BattleResultType.Lose);
-            BattleManager.instance.SetBattleResultType(BattleResultType.Lose);
-            await BattleManager.instance.BattleResultAsync(null);
+            await BattleManager.instance.ForceGameEndAsync();
         }
 
-        //SoundManager.instance.PlaySE(SE_TYPE.Heal);
-        await UniTask.Yield(token);
+        //SoundManager.instance.PlaySE(SE_TYPE.Heal);        
     }
 }

--- a/Assets/Scripts/MemoryGame/Trap/FlipCountDownTrapExecutor.cs
+++ b/Assets/Scripts/MemoryGame/Trap/FlipCountDownTrapExecutor.cs
@@ -1,0 +1,13 @@
+﻿using Cysharp.Threading.Tasks;
+using System.Threading;
+using UnityEngine;
+
+public class FlipCountDownTrapExecutor : ITrap {
+    public async UniTask ExecuteAsync(TrapData trapData, CancellationToken token) {
+        GameData.instance.userData.FlipPoint.Value = Mathf.Max(GameData.instance.userData.FlipPoint.Value - (int)trapData.value, 0);
+
+        //SoundManager.instance.PlaySE(SE_TYPE.Heal);
+
+        await UniTask.Yield(token);
+    }
+}

--- a/Assets/Scripts/MemoryGame/Trap/FlipCountDownTrapExecutor.cs.meta
+++ b/Assets/Scripts/MemoryGame/Trap/FlipCountDownTrapExecutor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 49f6f59a388cbaa438a51473e533d517

--- a/Assets/Scripts/MemoryGame/Trap/TrapExecutor.cs
+++ b/Assets/Scripts/MemoryGame/Trap/TrapExecutor.cs
@@ -8,7 +8,7 @@ public class TrapExecutor {
     public TrapExecutor() {
         executorMap = new() {
             { TrapType.Damage, new DamageTrapExecutor() },
-            
+            { TrapType.FlipCountDown, new FlipCountDownTrapExecutor() },
         };
     }
 

--- a/Assets/Scripts/Wodertale/BattleManager.cs
+++ b/Assets/Scripts/Wodertale/BattleManager.cs
@@ -528,4 +528,15 @@ public class BattleManager : AbstractSingleton<BattleManager> {
     public void SetBattleResultType(BattleResultType newBattleResultType) {
         battleResultType = newBattleResultType;
     }
+
+    /// <summary>
+    /// 強制的にゲームオーバー
+    /// 主にトラップでHp 0 やめくる回数 0 になった時に実行
+    /// </summary>
+    /// <returns></returns>
+    public async UniTask ForceGameEndAsync() {
+        SetBattleResultType(BattleResultType.Lose);
+        stageUIManager.ShowBattleState(battleResultType);
+        await BattleResultAsync(null);
+    }
 }


### PR DESCRIPTION
・回数 0 の際のゲームオーバー処理がデバッグのものだったので、バトルの方へつなぎ変え。
　ダメージによるゲームオーバー処理も合わせて変更。

・ターン終了時のタイミングを購読可能なイベントを追加。