### PR TITLE
祝福とトラップの効果を追加。

### DIFF
--- a/Assets/Scripts/MemoryGame/CardFactory.cs
+++ b/Assets/Scripts/MemoryGame/CardFactory.cs
@@ -26,7 +26,7 @@ public class CardFactory {
     public void InitExecutors(MemoryGameManager memoryGameManager, BattleManager battleManager, TrapDisarmQTEManager trapDisarmQTEManager, MemoryLinkManager memoryLinkManager, PlayerInventoryManager playerInventoryManager, ItemInfoDisplayManager itemInfoDisplayManager, ConditionManager conditionManager, StageUIManager stageUIManager) {
         // 各 Executor 生成
         battleExecutor = new BattleExecutor(battleManager);
-        trapExecutor = new TrapExecutor(battleManager, trapDisarmQTEManager, conditionManager, memoryGameManager, itemInfoDisplayManager);
+        trapExecutor = new TrapExecutor(battleManager, trapDisarmQTEManager, conditionManager, memoryGameManager, itemInfoDisplayManager, playerInventoryManager);
         memoriaRankUpExecutor = new MemoriaRankUpExecutor(memoryLinkManager);
         treasureGetExecutor = new TreasureGetExecutor(itemInfoDisplayManager, playerInventoryManager);
         eventExecutor = new EventExecutor(battleManager, memoryGameManager, playerInventoryManager, conditionManager);

--- a/Assets/Scripts/MemoryGame/Event/ChangeCardsByTypeEventExecutor.cs
+++ b/Assets/Scripts/MemoryGame/Event/ChangeCardsByTypeEventExecutor.cs
@@ -1,0 +1,22 @@
+﻿using Cysharp.Threading.Tasks;
+using System.Threading;
+
+/// <summary>
+/// 指定した種類のカードを別の種類のカードに変更するイベント実行クラス
+/// 現在は CardEvetType を TreasureChest に変更するのみ対応(汎用的にする場合には、BlessingData に新しいカラムを追加する)
+/// </summary>
+public class ChangeCardsByTypeEventExecutor : IEventExecutor {
+    private MemoryGameManager memoryGameManager;
+
+    public ChangeCardsByTypeEventExecutor(MemoryGameManager memoryGameManager) {
+        this.memoryGameManager = memoryGameManager;
+    }
+
+    public async UniTask ExecuteAsync(BlessingData blessingData, CancellationToken token) {
+        CardEventType fromCardEventType = MemoryGameManager.ConvertCardEventTypeByBlessingValueType(blessingData.valueType);
+        CardEventType toCardEventType = CardEventType.TreasureChest;
+
+        memoryGameManager.ReplaceCardsByType(fromCardEventType, toCardEventType);
+        await UniTask.Yield(token);
+    }
+}

--- a/Assets/Scripts/MemoryGame/Event/ChangeCardsByTypeEventExecutor.cs.meta
+++ b/Assets/Scripts/MemoryGame/Event/ChangeCardsByTypeEventExecutor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2412cb0aaec576346b0b0f4d1e92fae3

--- a/Assets/Scripts/MemoryGame/Event/EventExecutor.cs
+++ b/Assets/Scripts/MemoryGame/Event/EventExecutor.cs
@@ -23,6 +23,7 @@ public class EventExecutor {
             { BlessingType.InventorySizeUp, new InventorySizeUpEventExecutor() },
             { BlessingType.EnhanceRandomItems, new EnhanceRandomItemsExecutor(playerInventoryManager, conditionManager) },
             { BlessingType.DestroyCardsByType, new DestroyCardsByTypeEventExecutor(memoryGameManager) },
+            { BlessingType.ChangeCardsByType, new ChangeCardsByTypeEventExecutor(memoryGameManager) },
 
         };
     }

--- a/Assets/Scripts/MemoryGame/Trap/DamageTrapExecutor.cs
+++ b/Assets/Scripts/MemoryGame/Trap/DamageTrapExecutor.cs
@@ -3,10 +3,11 @@ using System.Threading;
 using UnityEngine;
 
 /// <summary>
-/// ダメージ罠実行クラス
+/// ダメージトラップ実行クラス
 /// </summary>
 public class DamageTrapExecutor : ITrapEffect {
     private BattleManager battleManager;
+
     public DamageTrapExecutor(BattleManager battleManager) {
         this.battleManager = battleManager;
     }

--- a/Assets/Scripts/MemoryGame/Trap/DeleteItemTrapExecutor.cs
+++ b/Assets/Scripts/MemoryGame/Trap/DeleteItemTrapExecutor.cs
@@ -1,0 +1,18 @@
+﻿using Cysharp.Threading.Tasks;
+using System.Threading;
+
+/// <summary>
+/// アイテム破壊トラップ実行クラス
+/// </summary>
+public class DeleteItemTrapExecutor : ITrapEffect {
+    private PlayerInventoryManager playerInventoryManager;
+
+    public DeleteItemTrapExecutor(PlayerInventoryManager playerInventoryManager) {
+        this.playerInventoryManager = playerInventoryManager;
+    }
+
+    public async UniTask ExecuteTrapEffectAsync(TrapActionData trapActionData, CancellationToken token) {
+        playerInventoryManager.DeleteRandomItemFromInventory((int)trapActionData.value);
+        await UniTask.Yield(token);
+    }
+}

--- a/Assets/Scripts/MemoryGame/Trap/DeleteItemTrapExecutor.cs.meta
+++ b/Assets/Scripts/MemoryGame/Trap/DeleteItemTrapExecutor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ba16d5f17922bac4d861bda1a287f762

--- a/Assets/Scripts/MemoryGame/Trap/FlipCountDownTrapExecutor.cs
+++ b/Assets/Scripts/MemoryGame/Trap/FlipCountDownTrapExecutor.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 
 /// <summary>
-/// めくれる回数(行動回数)を減少させる罠実行クラス
+/// めくれる回数(行動回数)を減少させるトラップ実行クラス
 /// </summary>
 public class FlipCountDownTrapExecutor : ITrapEffect {
     public async UniTask ExecuteTrapEffectAsync(TrapActionData trapActionData, CancellationToken token) {

--- a/Assets/Scripts/MemoryGame/Trap/TrapActionType.cs
+++ b/Assets/Scripts/MemoryGame/Trap/TrapActionType.cs
@@ -10,4 +10,5 @@
     Deportation,
     ChangeAllCard,
     ChangeCardTypeFromTo,
+    DeleteItem,
 }

--- a/Assets/Scripts/MemoryGame/Trap/TrapExecutor.cs
+++ b/Assets/Scripts/MemoryGame/Trap/TrapExecutor.cs
@@ -12,17 +12,19 @@ public class TrapExecutor {
     private ConditionManager conditionManager;
     private MemoryGameManager memoryGameManager;
     private ItemInfoDisplayManager itemInfoDisplayManager;
+    private PlayerInventoryManager playerInventoryManager;
 
     private readonly Dictionary<TrapActionType, ITrapEffect> executorMap;
     private readonly int symbolTypeCount = 4;    // QTEシンボル種類数
     private readonly float timeLimitSeconds = 5f; // QTE制限時間(秒)   ConstantData から取得するように変更
 
-    public TrapExecutor(BattleManager battleManager, TrapDisarmQTEManager trapDisarmQTEManager, ConditionManager conditionManager, MemoryGameManager memoryGameManager, ItemInfoDisplayManager itemInfoDisplayManager) {
+    public TrapExecutor(BattleManager battleManager, TrapDisarmQTEManager trapDisarmQTEManager, ConditionManager conditionManager, MemoryGameManager memoryGameManager, ItemInfoDisplayManager itemInfoDisplayManager, PlayerInventoryManager playerInventoryManager) {
         this.battleManager = battleManager;
         this.trapDisarmQTEManager = trapDisarmQTEManager;
         this.conditionManager = conditionManager;
         this.memoryGameManager = memoryGameManager;
         this.itemInfoDisplayManager = itemInfoDisplayManager;
+        this.playerInventoryManager = playerInventoryManager;
 
         executorMap = new() {
             { TrapActionType.Damage, new DamageTrapExecutor(battleManager) },
@@ -31,6 +33,7 @@ public class TrapExecutor {
             { TrapActionType.DeleteTargetCard, new DestroyTargetCardTrapExecutor(memoryGameManager)},
             { TrapActionType.ChangeCardTypeFromTo, new ChangeCardTypeFromToTrapExevutor(memoryGameManager)},
             { TrapActionType.ChangeAllCard, new ChangeAllCardsTypeToTrapExecutor(memoryGameManager)},
+            { TrapActionType.DeleteItem, new DeleteItemTrapExecutor(playerInventoryManager) },
         };
 
         float timeLimitFromData = float.Parse(DataBaseManager.instance.GetConstantDataValue("LIMIT_TRAP_DISARM_TIME_SECOND"));

--- a/Assets/Scripts/Wodertale/BackPackInItem.cs
+++ b/Assets/Scripts/Wodertale/BackPackInItem.cs
@@ -696,6 +696,14 @@ public class BackPackInItem : PoolBase {
         }
     }
 
+    /// <summary>
+    /// アイテム破棄
+    /// </summary>
+    public void DestoryItem() {
+        AddPriceToMoney(ReleaseType.Destroy);
+        Release();
+    }
+
     private void AddPriceToMoney(ReleaseType releaseType) {
         int price = releaseType switch {
             ReleaseType.Destroy => 0, //itemData.price / 2,

--- a/Assets/Scripts/Wodertale/PlayerInventoryManager.cs
+++ b/Assets/Scripts/Wodertale/PlayerInventoryManager.cs
@@ -721,6 +721,30 @@ public class PlayerInventoryManager : MonoBehaviour {
         }
     }
 
+    /// <summary>
+    /// インベントリ内のランダムなアイテムを指定数削除
+    /// </summary>
+    /// <param name="count"></param>
+    public void DeleteRandomItemFromInventory(int count) {
+        if (PlayerBackPackItemList.Count == 0) {
+            DebugLogger.Log($"インベントリが空です");
+            return;
+        }
+
+        // インベントリリストをランダムにシャッフルする
+        List<BackPackInItem> shuffledList = PlayerBackPackItemList.OrderBy(x => Guid.NewGuid()).ToList();
+
+        // 削除可能な範囲内で、指定された数だけ削除リストを作成(Take は最大値取るので足りなくてもエラーにはならない)
+        int deleteCount = Mathf.Min(count, PlayerBackPackItemList.Count);
+        List<BackPackInItem> deleteList = shuffledList.Take(deleteCount).ToList();
+
+        // シャッフルされたリストから最初から順に要素を取得して削除
+        for (int i = 0; i < deleteList.Count; i++) {
+            BackPackInItem backPackInItem = deleteList[i];
+            backPackInItem.DestoryItem();
+        }
+    }
+
     private void OnDestory() {
         disposables?.Clear();
     }


### PR DESCRIPTION
・指定したカードタイプを別のカードタイプに祝福効果を追加(現時点ではトラップを宝箱に)。

・アイテムを削除するトラップ効果を追加。こちらを利用し、電撃と爆弾を実装。