### PR TITLE
トラップの出現確率を、レアリティではなく、Tier 制にして、AnimationCurve を利用して重みに使う修正を算出するように修正

### DIFF
--- a/Assets/Prefabs/GameSettings.prefab
+++ b/Assets/Prefabs/GameSettings.prefab
@@ -1,0 +1,48 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5197957901365228744
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2392478042670685482}
+  - component: {fileID: 4930235203859194874}
+  m_Layer: 0
+  m_Name: GameSettings
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2392478042670685482
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5197957901365228744}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4930235203859194874
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5197957901365228744}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d519520d3a9b55a4b9d2416e255ccf8c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::GameSettings
+  isDontDestroy: 1
+  trapBalanceSettings: {fileID: 11400000, guid: baefeffafee320242968566f7af0d60f, type: 2}

--- a/Assets/Prefabs/GameSettings.prefab.meta
+++ b/Assets/Prefabs/GameSettings.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 949aef39e660a8c48bc408bab8a4b3cc
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/LeaderBoard.prefab
+++ b/Assets/Prefabs/LeaderBoard.prefab
@@ -1021,7 +1021,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2134628994694782351
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1692,7 +1692,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 6c75c0c49e293c04eb0c1d9e7d67a8b8, type: 3}
+  m_Sprite: {fileID: 21300000, guid: faf8f0eeb5cd1204699cb452ee5fcba1, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -2100,7 +2100,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &3165583570837424715
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Title.unity
+++ b/Assets/Scenes/Title.unity
@@ -459,6 +459,7 @@ MonoBehaviour:
   - {fileID: 8307963510195285174}
   - {fileID: 7330093965778943630}
   cgDifficultySelect: {fileID: 7613954201082629204}
+  difficultyToggleGroup: {fileID: 1173006221429979684}
 --- !u!114 &428536679
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7196,6 +7197,63 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1001 &6765564148453268819
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2392478042670685482, guid: 949aef39e660a8c48bc408bab8a4b3cc, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2392478042670685482, guid: 949aef39e660a8c48bc408bab8a4b3cc, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2392478042670685482, guid: 949aef39e660a8c48bc408bab8a4b3cc, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2392478042670685482, guid: 949aef39e660a8c48bc408bab8a4b3cc, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2392478042670685482, guid: 949aef39e660a8c48bc408bab8a4b3cc, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2392478042670685482, guid: 949aef39e660a8c48bc408bab8a4b3cc, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2392478042670685482, guid: 949aef39e660a8c48bc408bab8a4b3cc, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2392478042670685482, guid: 949aef39e660a8c48bc408bab8a4b3cc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2392478042670685482, guid: 949aef39e660a8c48bc408bab8a4b3cc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2392478042670685482, guid: 949aef39e660a8c48bc408bab8a4b3cc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5197957901365228744, guid: 949aef39e660a8c48bc408bab8a4b3cc, type: 3}
+      propertyPath: m_Name
+      value: GameSettings
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 949aef39e660a8c48bc408bab8a4b3cc, type: 3}
 --- !u!114 &6766680558992035204
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8471,6 +8529,7 @@ SceneRoots:
   - {fileID: 469310162}
   - {fileID: 879387668}
   - {fileID: 1278502641}
+  - {fileID: 6765564148453268819}
   - {fileID: 866491728}
   - {fileID: 1503230418}
   - {fileID: 882866815}

--- a/Assets/Scripts/Datas/EnemyData.cs
+++ b/Assets/Scripts/Datas/EnemyData.cs
@@ -18,7 +18,7 @@ public enum EnemyType {
 
 
 [System.Serializable]
-public class EnemyData : IMasterData, IInfoView, IHasIcon {
+public class EnemyData : IMasterData, IInfoView, IHasIcon, IExp {
     public int enemyNo;
     public Rarity rarity;
     public string race;
@@ -46,6 +46,8 @@ public class EnemyData : IMasterData, IInfoView, IHasIcon {
     public string Name => race;
 
     public string Description => "";
+
+    public int Exp => exp;
 
     public Sprite GetIcon() {
         return Resources.Load<Sprite>("Enemy/" + Id);

--- a/Assets/Scripts/Datas/FloorData.cs
+++ b/Assets/Scripts/Datas/FloorData.cs
@@ -28,6 +28,8 @@ public class FloorData : IMasterData {
     public int[] blessingRate;
     public int clearFlipBonus;               // フロアクリア時のめくれる回数ボーナス
     public float conditionPowerMultiplier;   // コンディションの強度の補正値
+    public int minTrapTier;                  // 出現するトラップの最低ティア
+    public int maxTrapTier;                  // 出現するトラップの最高ティア
 
     public int Id => id;
 
@@ -66,5 +68,7 @@ public class FloorData : IMasterData {
         clearFlipBonus = int.Parse(datas[23]);
 
         conditionPowerMultiplier = float.Parse(datas[24]);
+        minTrapTier = int.Parse(datas[25]);
+        maxTrapTier = int.Parse(datas[26]);
     }
 }

--- a/Assets/Scripts/Datas/TrapBalanceSettings.asset
+++ b/Assets/Scripts/Datas/TrapBalanceSettings.asset
@@ -1,0 +1,38 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f0a6f5581820074abbfba5bd0a8597c, type: 3}
+  m_Name: TrapBalanceSettings
+  m_EditorClassIdentifier: Assembly-CSharp::TrapBalanceSettings
+  tierWeightCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: -0.0007352164
+      value: 0.16570933
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4

--- a/Assets/Scripts/Datas/TrapBalanceSettings.asset.meta
+++ b/Assets/Scripts/Datas/TrapBalanceSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: baefeffafee320242968566f7af0d60f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Datas/TrapBalanceSettings.cs
+++ b/Assets/Scripts/Datas/TrapBalanceSettings.cs
@@ -1,0 +1,6 @@
+﻿using UnityEngine;
+
+[CreateAssetMenu(fileName = "TrapBalanceSettings", menuName = "Create TrapBalanceSettings")]
+public class TrapBalanceSettings : ScriptableObject {
+    public AnimationCurve tierWeightCurve;
+}

--- a/Assets/Scripts/Datas/TrapBalanceSettings.cs.meta
+++ b/Assets/Scripts/Datas/TrapBalanceSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6f0a6f5581820074abbfba5bd0a8597c

--- a/Assets/Scripts/Datas/TrapData.cs
+++ b/Assets/Scripts/Datas/TrapData.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 [System.Serializable]
-public class TrapData : IMasterData, IInfoView, IHasIcon {
+public class TrapData : IMasterData, IInfoView, IHasIcon, IExp {
     public int id;
     public string name;
     public string desc;
@@ -11,6 +11,7 @@ public class TrapData : IMasterData, IInfoView, IHasIcon {
     public int weight;
     public int exp;
     public int implemented;
+    public int tier;          // トラップのティア
 
     public List<TrapActionData> trapActionDataList = new();
 
@@ -23,6 +24,8 @@ public class TrapData : IMasterData, IInfoView, IHasIcon {
         return Resources.Load<Sprite>("Trap/" + Id);
     }
 
+    public int Exp => exp;
+
     public TrapData(string[] datas) {
         id = int.Parse(datas[0]);
         name = datas[1];
@@ -31,6 +34,7 @@ public class TrapData : IMasterData, IInfoView, IHasIcon {
         weight = int.Parse(datas[4]);
         exp = int.Parse(datas[5]);
         implemented = int.Parse(datas[6]);
+        tier = int.Parse(datas[7]);
 
         trapActionDataList = DataBaseManager.instance.GetTrapActionDataList(id);
     }

--- a/Assets/Scripts/Manager/MemoryGameManager.cs
+++ b/Assets/Scripts/Manager/MemoryGameManager.cs
@@ -601,7 +601,7 @@ public class MemoryGameManager : MonoBehaviour {
             case CardEventType.Trap:
                 chosenData = debugTrapID != 0   // debugIDが 0 以外なら、指定 ID のトラップデバッグ。0 なら通常処理
                            ? DataBaseManager.instance.trapDataSO.trapDataList.FirstOrDefault(data => data.id == debugTrapID)
-                           : DataBaseManager.instance.GetRandomTrapByRarity(floorData.trapRarities, floorData.trapRates);
+                           : DataBaseManager.instance.GetRandomTrapByTier(floorData); // Tier で抽選。Rarity は GetRandomTrapByRarity(floorData.trapRarities, floorData.trapRates);
                 break;
             case CardEventType.Blessing:
                 chosenData = debugBlessingID != 0   // debugIDが 0 以外なら、指定 ID のイベントデバッグ。0 なら通常処理
@@ -924,7 +924,7 @@ public class MemoryGameManager : MonoBehaviour {
     /// </summary>
     /// <param name="blessingData"></param>
     /// <returns></returns>
-    public async UniTask<bool> ChooseDestroyEnemyOrTrapCardAsync(BlessingData blessingData) {
+    public async UniTask<bool> ChooseDestroyEnemyOrTrapCardAsync(BlessingData blessingData, ReleaseType releaseType) {
 
         // 敵かトラップの「残っている Model」を取得
         List<CardModelBase> restEnemyModels = cardModelList
@@ -981,7 +981,7 @@ public class MemoryGameManager : MonoBehaviour {
         }
 
         // ペア破壊
-        await DestroyTargetPairCard(targetModels[0], firstView, targetModels[1], secondView);
+        await DestroyTargetPairCard(targetModels[0], firstView, targetModels[1], secondView, releaseType);
         return true;
     }
 
@@ -993,7 +993,9 @@ public class MemoryGameManager : MonoBehaviour {
     /// <param name="secoundCardModel"></param>
     /// <param name="secoundCardView"></param>
     /// <returns></returns>
-    private async UniTask DestroyTargetPairCard(CardModelBase firstCardModel, CardView firstCardView, CardModelBase secoundCardModel, CardView secoundCardView) {
+    private async UniTask DestroyTargetPairCard(CardModelBase firstCardModel, CardView firstCardView, CardModelBase secoundCardModel, CardView secoundCardView, ReleaseType releaseType) {
+        DebugLogger.Log("カード破棄実行");
+        
         // View 側状態更新
         firstCardView.isPaired = true;
         secoundCardView.isPaired = true;
@@ -1001,15 +1003,25 @@ public class MemoryGameManager : MonoBehaviour {
         firstCardModel.SetPair();
         secoundCardModel.SetPair();
 
+        // ReleaseType が Distribute の場合、ソウルポイント獲得対象なので、カードの種類とフロアデータから、カードのマスターデータを設定
+        IMasterData masterData = null;
+        if(releaseType == ReleaseType.Distribute) {
+            masterData = CreateCardData(firstCardModel.cardData.cardTypeMaster.cardEventType, currentFloorData);
+        }
+        //DebugLogger.Log($"firstCardModel.cardData.cardTypeMaster.cardEventType {firstCardModel.cardData.cardTypeMaster.cardEventType} / masterData : {masterData}");
+
+        // Exp が獲得できるカードの場合、Exp 獲得処理を実行
+        if (masterData is IExp expGiver) {  // is のパターンマッチング(null チェックも自動で行う)
+            int expAmount = expGiver.Exp;
+            GameData.instance.CalcSoulPoint(expAmount);
+            //DebugLogger.Log($"カードの効果により Exp 獲得 : {expAmount}");
+        }
+
         // ペア破壊アニメーションが両方終了するまで待機
         await UniTask.WhenAll(
             firstCardView.PlayHideAnimationAsync(cts.Token),
             secoundCardView.PlayHideAnimationAsync(cts.Token)
         );
-
-        // カードの効果を実行
-        if (this == null || secoundCardModel == null || cts == null) return;
-        DebugLogger.Log("カード破棄実行");
     }
 
     /// <summary>
@@ -1017,7 +1029,7 @@ public class MemoryGameManager : MonoBehaviour {
     /// </summary>
     /// <param name="targetType"></param>
     /// <returns></returns>
-    public async UniTask<bool> DestroyOnePairByTypeAsync(CardEventType targetType) {
+    public async UniTask<bool> DestroyOnePairByTypeAsync(CardEventType targetType, ReleaseType releaseType) {
         List<CardModelBase> restModels = cardModelList
             .Where(model =>
                 !model.isPair &&
@@ -1037,18 +1049,21 @@ public class MemoryGameManager : MonoBehaviour {
             return false;
         }
 
-        await DestroyTargetPairCard(
-            pairModels[0], firstView,
-            pairModels[1], secondView
-        );
+        // ペア破壊
+        await DestroyTargetPairCard(pairModels[0], firstView, pairModels[1], secondView, releaseType);
 
         return true;
     }
 
-
-    public async UniTask DestroyAllPairsByTypeAsync(CardEventType targetCardEventType) {
+    /// <summary>
+    /// 指定したタイプのカードペアをすべて破壊する
+    /// </summary>
+    /// <param name="targetCardEventType"></param>
+    /// <param name="releaseType"></param>
+    /// <returns></returns>
+    public async UniTask DestroyAllPairsByTypeAsync(CardEventType targetCardEventType, ReleaseType releaseType) {
         while (true) {
-            bool isDestroyed = await DestroyOnePairByTypeAsync(targetCardEventType);
+            bool isDestroyed = await DestroyOnePairByTypeAsync(targetCardEventType, releaseType);
             if (!isDestroyed) {
                 break;
             }

--- a/Assets/Scripts/MasterData/MasterTableBase.cs
+++ b/Assets/Scripts/MasterData/MasterTableBase.cs
@@ -37,6 +37,11 @@ public interface IInfoView {
     string Description { get; }
 }
 
+
+public interface IExp {
+    int Exp { get; }
+}
+
 /// <summary>
 /// IMasterData インターフェースを実装しているマスターデータをテーブル化する抽象クラス
 /// </summary>

--- a/Assets/Scripts/MemoryGame/Event/DestroyCardEventExecutor.cs
+++ b/Assets/Scripts/MemoryGame/Event/DestroyCardEventExecutor.cs
@@ -13,7 +13,7 @@ public class DestroyCardEventExecutor : IEventExecutor {
     public async UniTask ExecuteAsync(BlessingData blessingData, CancellationToken token) {
         // 指定回数だけ、敵かトラップカードを破棄
         for (int i = 0; i < blessingData.value; i++) {
-            bool destroyed = await memoryGameManager.ChooseDestroyEnemyOrTrapCardAsync(blessingData);
+            bool destroyed = await memoryGameManager.ChooseDestroyEnemyOrTrapCardAsync(blessingData, ReleaseType.Distribute);
 
             // 破棄されなかった(破棄可能なカードがなかった)場合にはループを抜ける
             if (!destroyed) {

--- a/Assets/Scripts/MemoryGame/Event/DestroyCardsByTypeEventExecutor.cs
+++ b/Assets/Scripts/MemoryGame/Event/DestroyCardsByTypeEventExecutor.cs
@@ -15,6 +15,6 @@ public class DestroyCardsByTypeEventExecutor : IEventExecutor {
     public async UniTask ExecuteAsync(BlessingData blessingData, CancellationToken token) {
         // 指定したタイプのカードペアをすべて破壊する
         CardEventType targetCardEventType = MemoryGameManager.ConvertCardEventTypeByBlessingValueType(blessingData.valueType);
-        await memoryGameManager.DestroyAllPairsByTypeAsync(targetCardEventType);
+        await memoryGameManager.DestroyAllPairsByTypeAsync(targetCardEventType, ReleaseType.Distribute);
     }
 }

--- a/Assets/Scripts/MemoryGame/GameSettings.cs
+++ b/Assets/Scripts/MemoryGame/GameSettings.cs
@@ -1,0 +1,3 @@
+﻿public class GameSettings : AbstractSingleton<GameSettings> {
+    public TrapBalanceSettings trapBalanceSettings;
+}

--- a/Assets/Scripts/MemoryGame/GameSettings.cs.meta
+++ b/Assets/Scripts/MemoryGame/GameSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d519520d3a9b55a4b9d2416e255ccf8c

--- a/Assets/Scripts/MemoryGame/MemoriaRankUpExecutor.cs
+++ b/Assets/Scripts/MemoryGame/MemoriaRankUpExecutor.cs
@@ -22,8 +22,11 @@ public class MemoriaRankUpExecutor {
         bool isRankUp = GameData.instance.CheckMemoriaRankUp();
 
         if (isRankUp) {
+            // TODO 一旦コメントアウト
             // 獲得した思い出の秘石の情報をポップアップで表示
-            await memoryLinkManager.ShowMemoryLinkPopup();
+            //await memoryLinkManager.ShowMemoryLinkPopup();
         }
+
+        await UniTask.Yield(token);
     }
 }

--- a/Assets/Scripts/MemoryGame/Trap/DestroyTargetCardTrapExecutor.cs
+++ b/Assets/Scripts/MemoryGame/Trap/DestroyTargetCardTrapExecutor.cs
@@ -12,7 +12,7 @@ public class DestroyTargetCardTrapExecutor : ITrapEffect {
 
 
     public async UniTask ExecuteTrapEffectAsync(TrapActionData trapActionData, CancellationToken token) {
-        // 指定されたタイプのカードペアをすべて破壊する
-        await memoryGameManager.DestroyAllPairsByTypeAsync(trapActionData.toCardEventType);
+        // 指定されたタイプのカードペアをすべて破壊する(ソウルポイントはもらえない)
+        await memoryGameManager.DestroyAllPairsByTypeAsync(trapActionData.toCardEventType, ReleaseType.Destroy);
     }
 }

--- a/Assets/Scripts/Wodertale/BackPackInItem.cs
+++ b/Assets/Scripts/Wodertale/BackPackInItem.cs
@@ -699,8 +699,8 @@ public class BackPackInItem : PoolBase {
     /// <summary>
     /// アイテム破棄
     /// </summary>
-    public void DestoryItem() {
-        AddPriceToMoney(ReleaseType.Destroy);
+    public void DestoryItem(ReleaseType releaseType) {
+        AddPriceToMoney(releaseType);
         Release();
     }
 

--- a/Assets/Scripts/Wodertale/BattleManager.cs
+++ b/Assets/Scripts/Wodertale/BattleManager.cs
@@ -272,14 +272,15 @@ public class BattleManager : MonoBehaviour, IPoisonDamageApplier {
         float settlementRate = playerInventoryManager.GetSettlementRate();
         //DebugLogger.Log($"settlementRate : {settlementRate}");
 
-        float settlementBonus = GameData.instance.charaStatus.GetReactionBonusRate(StatusType.Charm);
+        // TODO ステータスの反映は一旦なし
+        //float settlementBonus = GameData.instance.charaStatus.GetReactionBonusRate(StatusType.Charm);
         //DebugLogger.Log($"settlementBonus : {settlementBonus}");
 
         float randomSettlementValue = UnityEngine.Random.Range(0, 100.00f);
         //DebugLogger.Log($"settlement randomValue : {randomSettlementValue}");
 
         // 合計
-        settlementRate += settlementBonus;
+        //settlementRate += settlementBonus;
 
         // 交渉成功時にはバトルなし
         if (randomSettlementValue <= settlementRate) {

--- a/Assets/Scripts/Wodertale/DataBaseManager.cs
+++ b/Assets/Scripts/Wodertale/DataBaseManager.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using UnityEngine.UIElements;
 
 public class DataBaseManager : AbstractSingleton<DataBaseManager> {
     public CardTypeSO cardTypeSO;
@@ -164,6 +163,75 @@ public class DataBaseManager : AbstractSingleton<DataBaseManager> {
     }
 
     /// <summary>
+    /// Tier を利用し、フロアごとのランダムなトラップを取得
+    /// </summary>
+    /// <param name=""></param>
+    /// <returns></returns>
+    public TrapData GetRandomTrapByTier(FloorData floorData) {
+        // フロアの Tier からトラップの候補 List を取得
+        List<TrapData> candidateList = GetTrapDataListByTier(floorData);
+
+        if (candidateList == null || candidateList.Count == 0) {
+            DebugLogger.Log($"指定 Tier のトラップが存在しません。");
+            return null;
+        }
+
+        float totalWeight = 0f;
+        Dictionary<TrapData, float> weightTable = new ();
+
+        // Tier に補正を反映してトラップの重み付け計算
+        foreach (TrapData trap in candidateList) {
+            float tierRatio = 0.0f;
+
+            // Tier Ratio の計算
+            if (floorData.maxTrapTier == floorData.minTrapTier) {
+                tierRatio = 1f;
+            } else {
+                // 0.0 〜 1.0 の範囲で正規化
+                tierRatio = (trap.tier - floorData.minTrapTier) / (float)(floorData.maxTrapTier - floorData.minTrapTier);
+            }
+
+            // 念のため、Clamp して範囲内に収める
+            tierRatio = Mathf.Clamp01(tierRatio);
+
+            // Tier Range に応じた AnimataionCurve 補正の強さを計算(tierRange が高くなるほど、カーブをそのまま使う)
+            int tierRange = floorData.maxTrapTier - floorData.minTrapTier;
+            float curveStrength = Mathf.Clamp01((tierRange - 1) / 3.0f);
+            //DebugLogger.Log($"TrapID:{trap.id} TierRange:{tierRange} CurveStrength:{curveStrength}");
+
+            // Tier Ratio を元にした補正値を計算
+            float tierBonus = Mathf.Lerp(1f, GameSettings.instance.trapBalanceSettings.tierWeightCurve.Evaluate(tierRatio), curveStrength);
+            //DebugLogger.Log($"TrapID:{trap.id} Tier:{trap.tier} TierRatio:{tierRatio} TierBonus:{tierBonus}");
+
+            // 最終的な重みの値を算出
+            float effectiveWeight = trap.weight * tierBonus;
+
+            // 重みが 0 より大きいものだけを合計する
+            if (effectiveWeight > 0f) {
+                weightTable.Add(trap, effectiveWeight);
+                totalWeight += effectiveWeight;
+            }
+        }
+
+        if (totalWeight <= 0f) {
+            return null;
+        }
+
+        // 重み付きランダム抽選
+        float rand = Random.Range(0f, totalWeight);
+
+        foreach (var pair in weightTable) {
+            rand -= pair.Value;
+            if (rand <= 0f) {
+                return pair.Key;
+            }
+        }
+
+        // 保険(通常はここに来ない)
+        return null;
+    }
+
+    /// <summary>
     /// レアリティの重み付けを利用したイベントの抽選
     /// </summary>
     /// <param name="blessingRarities"></param>
@@ -276,17 +344,29 @@ public class DataBaseManager : AbstractSingleton<DataBaseManager> {
         return blessingDataSO.blessingDataList.Where(data => data.implemented == 1 && data.rarity == rarity).ToList();
     }
 
-
+    /// <summary>
+    /// 未使用
+    /// </summary>
+    /// <param name="rarity"></param>
+    /// <returns></returns>
     public List<TrapData> GetTrapDataListByRarity(Rarity rarity) {
         // 実装済のトラップのみ対象
         return trapDataSO.trapDataList.Where(data => data.implemented == 1 && data.rarity == rarity).ToList();
     }
 
+    /// <summary>
+    /// 現在のフロアデータから出現可能なトラップの List を取得
+    /// </summary>
+    /// <param name="floorData"></param>
+    /// <returns></returns>
+    public List<TrapData> GetTrapDataListByTier(FloorData floorData) {
+        var candidateList = trapDataSO.trapDataList.Where(trap => trap.implemented == 1 && trap.tier >= floorData.minTrapTier && trap.tier <= floorData.maxTrapTier);
+        return candidateList.ToList();
+    }
 
     public ItemData GetItemData(int searchId) {
         return itemDataSO.itemDataList.FirstOrDefault(data => data.id == searchId);
     }
-
 
     public List<ItemData> GetItemDataListByRarity(Rarity rarity) {
         return itemDataSO.itemDataList.Where(data => data.rarity == rarity).ToList();

--- a/Assets/Scripts/Wodertale/PlayerInventoryManager.cs
+++ b/Assets/Scripts/Wodertale/PlayerInventoryManager.cs
@@ -741,7 +741,7 @@ public class PlayerInventoryManager : MonoBehaviour {
         // シャッフルされたリストから最初から順に要素を取得して削除
         for (int i = 0; i < deleteList.Count; i++) {
             BackPackInItem backPackInItem = deleteList[i];
-            backPackInItem.DestoryItem();
+            backPackInItem.DestoryItem(ReleaseType.Destroy);  // ソウルポイントはもらえない
         }
     }
 

--- a/Assets/Scripts/Wodertale/Title.cs
+++ b/Assets/Scripts/Wodertale/Title.cs
@@ -24,7 +24,11 @@ public class Title : MonoBehaviour {
     [SerializeField] private Button btnLevelSelect;
     [SerializeField] private DifficultySelectToggle[] difficultySelectToggles;
     [SerializeField] private CanvasGroup cgDifficultySelect;
-    protected CompositeDisposable disposables;
+    [SerializeField] private ToggleGroup difficultyToggleGroup;
+
+    private CompositeDisposable disposables;
+
+    private bool hasSelectedOnce = false;
 
 
     void Start() {
@@ -125,6 +129,12 @@ public class Title : MonoBehaviour {
 
                         // ゲームスタートボタンの活性化(目線誘導)
                         ActivateGameStartBtn();
+
+                        // 初回選択時のみトグル未選択状態になっているので、2回目以降は、未選択状態を許可しないようにする
+                        if (!hasSelectedOnce) {
+                            hasSelectedOnce = true;
+                            difficultyToggleGroup.allowSwitchOff = false;
+                        }
                     } else {
                         // 文字色の演出を戻す
                         difficultySelectToggles[index].Unchoose();


### PR DESCRIPTION
・AnimationCurve で出現確率を制御。

・GameSettings.cs、TrapBalanceSettings.cs スクリプタブルオブジェクト作成。

・祝福カードの効果で敵やトラップカードが破棄されたときにソウルポイントを獲得できるように修正。

・リーダーボードのアイコン画像を修正。

・ 交渉の算出に魅力の値を利用していたので一旦停止。

・タイトルで一度トグルを選択したら、以降は未選択状態が発生しないように修正。